### PR TITLE
[BE] 백카사전 API 

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -27,6 +27,7 @@ dependencies {
 
     //lombok
     implementation 'org.projectlombok:lombok:1.18.28'
+    annotationProcessor 'org.projectlombok:lombok:1.18.28'
 
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'com.h2database:h2'

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -25,6 +25,9 @@ dependencies {
     //swagger
     implementation 'org.springdoc:springdoc-openapi-ui:1.6.15'
 
+    //lombok
+    implementation 'org.projectlombok:lombok:1.18.28'
+
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/server/src/main/java/team/youngcha/domain/dictionary/Dictionary.java
+++ b/server/src/main/java/team/youngcha/domain/dictionary/Dictionary.java
@@ -1,0 +1,16 @@
+package team.youngcha.domain.dictionary;
+
+import lombok.Getter;
+import nonapi.io.github.classgraph.json.Id;
+
+@Getter
+public class Dictionary {
+    @Id
+    private Long id;
+
+    private String word;
+
+    private String description;
+
+    private String imgUrl;
+}

--- a/server/src/main/java/team/youngcha/domain/dictionary/Dictionary.java
+++ b/server/src/main/java/team/youngcha/domain/dictionary/Dictionary.java
@@ -1,7 +1,7 @@
 package team.youngcha.domain.dictionary;
 
 import lombok.Getter;
-import nonapi.io.github.classgraph.json.Id;
+import org.springframework.data.annotation.Id;
 
 @Getter
 public class Dictionary {
@@ -13,4 +13,10 @@ public class Dictionary {
     private String description;
 
     private String imgUrl;
+
+    public Dictionary(String word, String description, String imgUrl) {
+        this.word = word;
+        this.description = description;
+        this.imgUrl = imgUrl;
+    }
 }

--- a/server/src/main/java/team/youngcha/domain/dictionary/controller/DictionaryController.java
+++ b/server/src/main/java/team/youngcha/domain/dictionary/controller/DictionaryController.java
@@ -1,0 +1,31 @@
+package team.youngcha.domain.dictionary.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import team.youngcha.common.dto.SuccessResponse;
+import team.youngcha.domain.dictionary.service.DictionaryService;
+import team.youngcha.domain.dictionary.dto.FindDictionaryResponse;
+
+import java.util.List;
+
+@Tag(name = "Dictionary", description = "백카사전 API")
+@RestController
+@RequestMapping("/car-make/dictionary")
+@RequiredArgsConstructor
+public class DictionaryController {
+
+    private final DictionaryService dictionaryService;
+
+    @Operation(summary = "백카사전 전체 조회", description = "백카사전의 전체 데이터를 요청합니다")
+    @GetMapping
+    public ResponseEntity<SuccessResponse<List<FindDictionaryResponse>>> getDictionary() {
+        List<FindDictionaryResponse> dictionary = dictionaryService.findDictionary();
+        SuccessResponse<List<FindDictionaryResponse>> successResponse = new SuccessResponse<>(dictionary);
+        return ResponseEntity.ok(successResponse);
+    }
+}

--- a/server/src/main/java/team/youngcha/domain/dictionary/controller/DictionaryController.java
+++ b/server/src/main/java/team/youngcha/domain/dictionary/controller/DictionaryController.java
@@ -21,9 +21,9 @@ public class DictionaryController {
 
     private final DictionaryService dictionaryService;
 
-    @Operation(summary = "백카사전 전체 조회", description = "백카사전의 전체 데이터를 요청합니다")
+    @Operation(summary = "백카사전 전체 조회", description = "백카사전의 전체 데이터를 조회합니다")
     @GetMapping
-    public ResponseEntity<SuccessResponse<List<FindDictionaryResponse>>> getDictionary() {
+    public ResponseEntity<SuccessResponse<List<FindDictionaryResponse>>> findDictionary() {
         List<FindDictionaryResponse> dictionary = dictionaryService.findDictionary();
         SuccessResponse<List<FindDictionaryResponse>> successResponse = new SuccessResponse<>(dictionary);
         return ResponseEntity.ok(successResponse);

--- a/server/src/main/java/team/youngcha/domain/dictionary/dto/FindDictionaryResponse.java
+++ b/server/src/main/java/team/youngcha/domain/dictionary/dto/FindDictionaryResponse.java
@@ -2,20 +2,22 @@ package team.youngcha.domain.dictionary.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import team.youngcha.domain.dictionary.Dictionary;
 
 @Getter
+@NoArgsConstructor
 @Schema(description = "백카사전 데이터")
 public class FindDictionaryResponse {
 
     @Schema(description = "용어")
-    private final String word;
+    private String word;
 
     @Schema(description = "설명 내용")
-    private final String description;
+    private String description;
 
     @Schema(description = "설명 이미지")
-    private final String imgUrl;
+    private String imgUrl;
 
     public FindDictionaryResponse(final Dictionary dictionary) {
         this.word = dictionary.getWord();

--- a/server/src/main/java/team/youngcha/domain/dictionary/dto/FindDictionaryResponse.java
+++ b/server/src/main/java/team/youngcha/domain/dictionary/dto/FindDictionaryResponse.java
@@ -19,6 +19,12 @@ public class FindDictionaryResponse {
     @Schema(description = "설명 이미지")
     private String imgUrl;
 
+    public FindDictionaryResponse(String word, String description, String imgUrl) {
+        this.word = word;
+        this.description = description;
+        this.imgUrl = imgUrl;
+    }
+
     public FindDictionaryResponse(final Dictionary dictionary) {
         this.word = dictionary.getWord();
         this.description = dictionary.getDescription();

--- a/server/src/main/java/team/youngcha/domain/dictionary/dto/FindDictionaryResponse.java
+++ b/server/src/main/java/team/youngcha/domain/dictionary/dto/FindDictionaryResponse.java
@@ -1,0 +1,25 @@
+package team.youngcha.domain.dictionary.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import team.youngcha.domain.dictionary.Dictionary;
+
+@Getter
+@Schema(description = "백카사전 데이터")
+public class FindDictionaryResponse {
+
+    @Schema(description = "용어")
+    private final String word;
+
+    @Schema(description = "설명 내용")
+    private final String description;
+
+    @Schema(description = "설명 이미지")
+    private final String imgUrl;
+
+    public FindDictionaryResponse(final Dictionary dictionary) {
+        this.word = dictionary.getWord();
+        this.description = dictionary.getDescription();
+        this.imgUrl = dictionary.getImgUrl();
+    }
+}

--- a/server/src/main/java/team/youngcha/domain/dictionary/repository/DictionaryRepository.java
+++ b/server/src/main/java/team/youngcha/domain/dictionary/repository/DictionaryRepository.java
@@ -1,0 +1,9 @@
+package team.youngcha.domain.dictionary.repository;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+import team.youngcha.domain.dictionary.Dictionary;
+
+@Repository
+public interface DictionaryRepository extends CrudRepository<Dictionary, Long> {
+}

--- a/server/src/main/java/team/youngcha/domain/dictionary/service/DictionaryService.java
+++ b/server/src/main/java/team/youngcha/domain/dictionary/service/DictionaryService.java
@@ -1,0 +1,28 @@
+package team.youngcha.domain.dictionary.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import team.youngcha.domain.dictionary.Dictionary;
+import team.youngcha.domain.dictionary.dto.FindDictionaryResponse;
+import team.youngcha.domain.dictionary.repository.DictionaryRepository;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class DictionaryService {
+
+    private final DictionaryRepository dictionaryRepository;
+
+    public List<FindDictionaryResponse> findDictionary() {
+        List<FindDictionaryResponse> findDictionaryResponses = new ArrayList<>();
+
+        for(Dictionary dictionary : dictionaryRepository.findAll()) {
+            FindDictionaryResponse findDictionaryResponse = new FindDictionaryResponse(dictionary);
+            findDictionaryResponses.add(findDictionaryResponse);
+        }
+
+        return findDictionaryResponses;
+    }
+}

--- a/server/src/test/java/team/youngcha/domain/dictionary/DictionaryIntegrationTest.java
+++ b/server/src/test/java/team/youngcha/domain/dictionary/DictionaryIntegrationTest.java
@@ -1,0 +1,51 @@
+package team.youngcha.domain.dictionary;
+
+import io.restassured.RestAssured;
+import io.restassured.common.mapper.TypeRef;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.context.jdbc.Sql;
+import team.youngcha.IntegrationTestBase;
+import team.youngcha.common.dto.SuccessResponse;
+import team.youngcha.domain.dictionary.dto.FindDictionaryResponse;
+
+import java.util.List;
+
+@Sql({"classpath:data/dictionary.sql"})
+public class DictionaryIntegrationTest extends IntegrationTestBase {
+
+    @Test
+    @DisplayName("백과사전의 전체 항목을 조회한다")
+    void findDictionary() {
+        ExtractableResponse<Response> response = RestAssured
+                .given().log().all()
+
+                .when()
+                .get("/car-make/dictionary")
+
+                .then()
+                .log().all()
+                .extract();
+
+        SuccessResponse<List<FindDictionaryResponse>> successResponse = response.body().as(new TypeRef<>() {
+        });
+
+        softAssertions.assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+
+        softAssertions.assertThat(successResponse.getData().size()).isEqualTo(2);
+
+        softAssertions.assertThat(successResponse.getData().get(0).getWord()).isEqualTo("머플러");
+        softAssertions.assertThat(successResponse.getData().get(0).getDescription()).isEqualTo("엔진에서 발생한 배기가스를 차 밖으로 배출하는 장치에요.");
+        softAssertions.assertThat(successResponse.getData().get(0).getImgUrl()).isEqualTo("http://kids.hyundai.com/upload/image/FU/201704/170425_car_img06.png");
+
+        softAssertions.assertThat(successResponse.getData().get(1).getWord()).isEqualTo("파워 트레인");
+        softAssertions.assertThat(successResponse.getData().get(1).getDescription()).isEqualTo("엔진에서 구동바퀴사이의 모든 기관을 지칭하는 말이에요. 자동차 플랫폼과 비슷한 뜻이에요.");
+        softAssertions.assertThat(successResponse.getData().get(1).getImgUrl()).isEqualTo(null);
+
+        softAssertions.assertAll();
+    }
+
+}

--- a/server/src/test/java/team/youngcha/domain/dictionary/DictionaryIntegrationTest.java
+++ b/server/src/test/java/team/youngcha/domain/dictionary/DictionaryIntegrationTest.java
@@ -43,9 +43,7 @@ public class DictionaryIntegrationTest extends IntegrationTestBase {
 
         softAssertions.assertThat(successResponse.getData().get(1).getWord()).isEqualTo("파워 트레인");
         softAssertions.assertThat(successResponse.getData().get(1).getDescription()).isEqualTo("엔진에서 구동바퀴사이의 모든 기관을 지칭하는 말이에요. 자동차 플랫폼과 비슷한 뜻이에요.");
-        softAssertions.assertThat(successResponse.getData().get(1).getImgUrl()).isEqualTo(null);
-
-        softAssertions.assertAll();
+        softAssertions.assertThat(successResponse.getData().get(1).getImgUrl()).isNull();
     }
 
 }

--- a/server/src/test/java/team/youngcha/domain/dictionary/DictionaryIntegrationTest.java
+++ b/server/src/test/java/team/youngcha/domain/dictionary/DictionaryIntegrationTest.java
@@ -20,16 +20,28 @@ public class DictionaryIntegrationTest extends IntegrationTestBase {
     @Test
     @DisplayName("백과사전의 전체 항목을 조회한다")
     void findDictionary() {
+        //given
+        FindDictionaryResponse expectedResponse1 = new FindDictionaryResponse(
+                "머플러",
+                "엔진에서 발생한 배기가스를 차 밖으로 배출하는 장치에요.",
+                "http://kids.hyundai.com/upload/image/FU/201704/170425_car_img06.png");
+
+        FindDictionaryResponse expectedResponse2 = new FindDictionaryResponse(
+                "파워 트레인",
+                "엔진에서 구동바퀴사이의 모든 기관을 지칭하는 말이에요. 자동차 플랫폼과 비슷한 뜻이에요.",
+                null);
+
+        //when
         ExtractableResponse<Response> response = RestAssured
                 .given().log().all()
 
                 .when()
                 .get("/car-make/dictionary")
 
-                .then()
-                .log().all()
+                .then().log().all()
                 .extract();
 
+        //then
         SuccessResponse<List<FindDictionaryResponse>> successResponse = response.body().as(new TypeRef<>() {
         });
 
@@ -37,13 +49,12 @@ public class DictionaryIntegrationTest extends IntegrationTestBase {
 
         softAssertions.assertThat(successResponse.getData().size()).isEqualTo(2);
 
-        softAssertions.assertThat(successResponse.getData().get(0).getWord()).isEqualTo("머플러");
-        softAssertions.assertThat(successResponse.getData().get(0).getDescription()).isEqualTo("엔진에서 발생한 배기가스를 차 밖으로 배출하는 장치에요.");
-        softAssertions.assertThat(successResponse.getData().get(0).getImgUrl()).isEqualTo("http://kids.hyundai.com/upload/image/FU/201704/170425_car_img06.png");
+        softAssertions.assertThat(successResponse.getData().get(0))
+                .usingRecursiveComparison()
+                .isEqualTo(expectedResponse1);
 
-        softAssertions.assertThat(successResponse.getData().get(1).getWord()).isEqualTo("파워 트레인");
-        softAssertions.assertThat(successResponse.getData().get(1).getDescription()).isEqualTo("엔진에서 구동바퀴사이의 모든 기관을 지칭하는 말이에요. 자동차 플랫폼과 비슷한 뜻이에요.");
-        softAssertions.assertThat(successResponse.getData().get(1).getImgUrl()).isNull();
+        softAssertions.assertThat(successResponse.getData().get(1))
+                .usingRecursiveComparison()
+                .isEqualTo(expectedResponse2);
     }
-
 }

--- a/server/src/test/java/team/youngcha/test/TestIntegrationTest.java
+++ b/server/src/test/java/team/youngcha/test/TestIntegrationTest.java
@@ -1,8 +1,5 @@
 package team.youngcha.test;
 
-import team.youngcha.IntegrationTestBase;
-import team.youngcha.common.dto.ErrorResponse;
-import team.youngcha.common.dto.SuccessResponse;
 import io.restassured.RestAssured;
 import io.restassured.common.mapper.TypeRef;
 import io.restassured.response.ExtractableResponse;
@@ -12,6 +9,9 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import team.youngcha.IntegrationTestBase;
+import team.youngcha.common.dto.ErrorResponse;
+import team.youngcha.common.dto.SuccessResponse;
 
 class TestIntegrationTest extends IntegrationTestBase {
 

--- a/server/src/test/resources/data/dictionary.sql
+++ b/server/src/test/resources/data/dictionary.sql
@@ -1,0 +1,8 @@
+INSERT INTO dictionary (word, description, img_url)
+VALUES ('머플러',
+        '엔진에서 발생한 배기가스를 차 밖으로 배출하는 장치에요.',
+        'http://kids.hyundai.com/upload/image/FU/201704/170425_car_img06.png');
+
+INSERT INTO dictionary (word, description)
+VALUES ('파워 트레인',
+        '엔진에서 구동바퀴사이의 모든 기관을 지칭하는 말이에요. 자동차 플랫폼과 비슷한 뜻이에요.');


### PR DESCRIPTION
## 📕 요약
백카사전 조회 API(/car-make/dictionary) 구현
close #57
## 📗 작업 내용
- [x] 백카사전의 전체 항목을 조회하는 API 구현
  - [x] 백카사전 컨트롤러(DictionaryController), 서비스(DictionaryService), 리포지토리(DictionaryRepository) 클래스 작성 
  - [x] 백카사전 테이블과 대응되는 엔티티 클래스(Dictionary) 작성
  - [x] 백카사전 조회 API 응답 클래스(FindDictionaryResponse) 작성
- [x] 백카사전 조회 API 통합 테스트(DictionaryIntegrationTest) 작성
  - [x] SQL 스크립트를 활용하여 테스트 데이터 적용 
- [x] lombok 의존성 추가

## 📘 PR 특이 사항
- 전체적인 컨벤션 및 Swagger 코드 관련해서 피드백 부탁드립니다!