### PR TITLE
[FE] 공통 컴포넌트 버튼 구현

### DIFF
--- a/client/.storybook/preview.ts
+++ b/client/.storybook/preview.ts
@@ -1,4 +1,5 @@
 import type { Preview } from '@storybook/react';
+import '@/index.css';
 
 const preview: Preview = {
   parameters: {

--- a/client/src/components/Button/index.stories.tsx
+++ b/client/src/components/Button/index.stories.tsx
@@ -3,12 +3,27 @@ import Button from './index';
 
 const meta: Meta<typeof Button> = {
   component: Button,
+  argTypes: { onClick: { action: 'clicked' } },
 };
 
 export default meta;
 
 type Story = StoryObj<typeof Button>;
 
-export const FirstStory: Story = {
-  args: {},
+export const StorySize: Story = {
+  args: {
+    children: 'StorySize',
+    size: 'sm',
+    color: 'main-blue',
+    onClick: () => {},
+  },
+};
+
+export const StoryColor: Story = {
+  args: {
+    children: 'StoryColor',
+    size: 'sm',
+    color: 'grey',
+    onClick: () => {},
+  },
 };

--- a/client/src/components/Button/index.stories.tsx
+++ b/client/src/components/Button/index.stories.tsx
@@ -10,20 +10,47 @@ export default meta;
 
 type Story = StoryObj<typeof Button>;
 
-export const StorySize: Story = {
+export const Default: Story = {
   args: {
-    children: 'StorySize',
-    size: 'sm',
+    children: 'Default',
+    size: 'md',
     color: 'main-blue',
     onClick: () => {},
   },
 };
-
-export const StoryColor: Story = {
-  args: {
-    children: 'StoryColor',
-    size: 'sm',
-    color: 'grey',
-    onClick: () => {},
-  },
+export const Colors: Story = {
+  render: () => (
+    <>
+      <Button size="md" color="main-blue">
+        main-blue
+      </Button>
+      <Button size="md" color="white">
+        white
+      </Button>
+      <Button size="md" color="grey">
+        grey
+      </Button>
+    </>
+  ),
+};
+export const Sizes: Story = {
+  render: () => (
+    <>
+      <Button size="xl" color="main-blue">
+        xl
+      </Button>
+      <Button size="lg" color="main-blue">
+        lg
+      </Button>
+      <Button size="md" color="main-blue">
+        md
+      </Button>
+      <Button size="sm" color="main-blue">
+        sm
+      </Button>
+      <Button size="xs" color="main-blue">
+        xs
+      </Button>
+    </>
+  ),
 };

--- a/client/src/components/Button/index.tsx
+++ b/client/src/components/Button/index.tsx
@@ -22,15 +22,15 @@ function Button({ children, size, color, onClick }: ButtonProps) {
 function getButtonSize(size: string) {
   switch (size) {
     case 'xs':
-      return 'w-[80px] h-[32px]';
+      return 'w-80px h-32px';
     case 'sm':
-      return 'w-[113px] h-[46px]';
+      return 'w-113px h-46px';
     case 'md':
-      return 'w-[140px] h-[50px]';
+      return 'w-140px h-50px';
     case 'lg':
-      return 'w-[150px] h-[46px]';
+      return 'w-150px h-46px';
     case 'xl':
-      return 'w-[244px] h-[57px]';
+      return 'w-244px h-57px';
   }
 }
 

--- a/client/src/components/Button/index.tsx
+++ b/client/src/components/Button/index.tsx
@@ -1,48 +1,38 @@
 type ColorType = 'main-blue' | 'white' | 'grey';
 interface ButtonProps {
   children: React.ReactNode;
-  title: string;
-  size: 'xs' | 'sm' | 'md' | 'lg' | 'xl';
-  color: ColorType;
-  onClick: () => void;
+  size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl';
+  color?: ColorType;
+  onClick?: () => void;
 }
 
-function Button({ children, size, color, onClick }: ButtonProps) {
-  const buttonColor = getButtonColor(color);
-  const buttonSize = getButtonSize(size);
-  const className = `flex justify-center items-center rounded-[6px] ${buttonSize} ${buttonColor}`;
+const buttonSize = {
+  xs: 'w-80px h-32px',
+  sm: 'w-113px h-46px',
+  md: 'w-140px h-50px',
+  lg: 'w-150px h-46px',
+  xl: 'w-244px h-57px',
+};
+
+const buttonColor = {
+  'main-blue': 'bg-main-blue text-white',
+  'white': 'bg-white text-black border border-black',
+  'grey': 'bg-grey-001 text-main-blue',
+};
+
+function Button({
+  children,
+  size = 'md',
+  color = 'main-blue',
+  onClick,
+}: ButtonProps) {
+  const className = `flex justify-center items-center rounded-[6px] ${buttonSize[size]} ${buttonColor[color]}`;
 
   return (
     <button className={className} onClick={onClick}>
       {children}
     </button>
   );
-}
-
-function getButtonSize(size: string) {
-  switch (size) {
-    case 'xs':
-      return 'w-80px h-32px';
-    case 'sm':
-      return 'w-113px h-46px';
-    case 'md':
-      return 'w-140px h-50px';
-    case 'lg':
-      return 'w-150px h-46px';
-    case 'xl':
-      return 'w-244px h-57px';
-  }
-}
-
-function getButtonColor(color: string) {
-  switch (color) {
-    case 'main-blue':
-      return 'bg-main-blue text-white';
-    case 'white':
-      return 'bg-white text-black border border-black';
-    case 'grey':
-      return 'bg-grey-001 text-main-blue';
-  }
 }
 
 export default Button;

--- a/client/src/components/Button/index.tsx
+++ b/client/src/components/Button/index.tsx
@@ -1,11 +1,48 @@
-import { ReactNode } from 'react';
-
+type ColorType = 'main-blue' | 'white' | 'grey';
 interface ButtonProps {
-  children: ReactNode;
+  children: React.ReactNode;
+  title: string;
+  size: 'xs' | 'sm' | 'md' | 'lg' | 'xl';
+  color: ColorType;
+  onClick: () => void;
 }
 
-function Button({ children }: ButtonProps) {
-  return <button>{children}</button>;
+function Button({ children, size, color, onClick }: ButtonProps) {
+  const buttonColor = getButtonColor(color);
+  const buttonSize = getButtonSize(size);
+  const className = `flex justify-center items-center rounded-[6px] ${buttonSize} ${buttonColor}`;
+
+  return (
+    <button className={className} onClick={onClick}>
+      {children}
+    </button>
+  );
+}
+
+function getButtonSize(size: string) {
+  switch (size) {
+    case 'xs':
+      return 'w-[80px] h-[32px]';
+    case 'sm':
+      return 'w-[113px] h-[46px]';
+    case 'md':
+      return 'w-[140px] h-[50px]';
+    case 'lg':
+      return 'w-[150px] h-[46px]';
+    case 'xl':
+      return 'w-[244px] h-[57px]';
+  }
+}
+
+function getButtonColor(color: string) {
+  switch (color) {
+    case 'main-blue':
+      return 'bg-main-blue text-white';
+    case 'white':
+      return 'bg-white text-black border border-black';
+    case 'grey':
+      return 'bg-grey-001 text-main-blue';
+  }
 }
 
 export default Button;


### PR DESCRIPTION
## 📕 요약

### Image
<img width="130" alt="스크린샷 2023-08-09 오전 11 12 08" src="https://github.com/softeerbootcamp-2nd/H8-YoungCha/assets/37887690/ceb00768-6b85-4551-8a59-446e971ad9ec">

사이즈 및 색상 별 공통 버튼 컴포넌트 구현 

> xs -> width : 80px  height : 32px
sm -> width : 113px  height : 46px
md -> width : 140px  height : 50px
lg ->  width : 150px  height : 46px
xl -> width : 244px  height : 57px

디자인에는 총 5가지 크기의 버튼이 사용 되는것으로 보이는데 혹시 다른 크기가 있다면 알려주세요!!

## 📗 작업 내용

- [x] 공통 버튼 컴포넌트 구현
- [x] 스토리에 css 적용 버그 수정

