### PR TITLE
[AOS] 셀프 & 가이드 모드 - |이전 || 선택완료 | 버튼 기능 구현

### DIFF
--- a/android/app/src/main/java/com/youngcha/ohmycarset/ui/adapter/binding/BindingAdapter.kt
+++ b/android/app/src/main/java/com/youngcha/ohmycarset/ui/adapter/binding/BindingAdapter.kt
@@ -2,6 +2,7 @@ package com.youngcha.ohmycarset.ui.adapter.binding
 
 import android.annotation.SuppressLint
 import android.graphics.Color
+import android.util.Log
 import android.util.TypedValue
 import android.view.View
 import android.view.View.INVISIBLE

--- a/android/app/src/main/java/com/youngcha/ohmycarset/ui/adapter/viewpager/CarOptionPagerAdapter.kt
+++ b/android/app/src/main/java/com/youngcha/ohmycarset/ui/adapter/viewpager/CarOptionPagerAdapter.kt
@@ -36,6 +36,16 @@ class CarOptionPagerAdapter(private val viewModel: CarCustomizationViewModel) :
         this.currentType = currentType
         currentSelectedOptions = viewModel.isSelectedOptions(subOption!!) ?: listOf()
 
+        // 만약 현재 선택된 옵션이 없다면 0번째 옵션을 추가
+        if (currentSelectedOptions.isEmpty()) {
+            val firstOption = options.firstOrNull()
+            firstOption?.let {
+                if (optionType != OPTION_SELECTION) {
+                    viewModel.addCarComponents(viewModel.currentComponentName.value!!, it)
+                }
+            }
+        }
+
         if (animatedTabs[subOption]?.not() == true || animatedTabs[subOption] == null) {
             shouldAnimate = true
             animatedTabs[subOption] = true
@@ -68,7 +78,6 @@ class CarOptionPagerAdapter(private val viewModel: CarCustomizationViewModel) :
             layoutParams.setMargins(0, 0, 0, marginBottom)
             hyundaiButtonView.layoutParams = layoutParams
         }
-
         return ViewHolder(hyundaiButtonView)
     }
 

--- a/android/app/src/main/java/com/youngcha/ohmycarset/ui/fragment/CarCustomizationFragment.kt
+++ b/android/app/src/main/java/com/youngcha/ohmycarset/ui/fragment/CarCustomizationFragment.kt
@@ -9,6 +9,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.view.animation.AnimationSet
 import android.view.animation.AnimationUtils
+import android.widget.LinearLayout
 import android.widget.TextView
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
@@ -167,10 +168,22 @@ class CarCustomizationFragment : Fragment() {
         binding.vpOptionContainer.setCurrentItem(position, false)
     }
 
+
     private fun setupMainTabSelectionListener() {
-        binding.tlMainOptionTab.addOnTabSelectedListener(object : TabLayout.OnTabSelectedListener {
-            override fun onTabSelected(tab: TabLayout.Tab?) {
-                val tabName = tab?.text?.replace(Regex("^\\d+\\s"), "") ?: "Unknown"
+        binding.vMainTabLayoutOverlay.setOnTouchListener { _, _ -> true }
+
+        binding.btnPrev.setOnClickListener {
+            val currentTabIndex = binding.tlMainOptionTab.selectedTabPosition
+
+            // 이전 탭이 존재하는 경우에만 선택
+            if (currentTabIndex > 0) {
+                val prevTabIndex = currentTabIndex - 1
+                binding.tlMainOptionTab.getTabAt(prevTabIndex)?.select()
+
+                val tabName = binding.tlMainOptionTab.getTabAt(prevTabIndex)?.text?.replace(
+                    Regex("^\\d+\\s"),
+                    ""
+                ) ?: "Unknown"
                 carViewModel.setCurrentComponentName(tabName)
 
                 when (tabName) {
@@ -178,11 +191,28 @@ class CarCustomizationFragment : Fragment() {
                     else -> handleDefaultTab()
                 }
             }
+        }
 
-            override fun onTabUnselected(tab: TabLayout.Tab?) {}
+        binding.btnNext.setOnClickListener {
+            val currentTabIndex = binding.tlMainOptionTab.selectedTabPosition
 
-            override fun onTabReselected(tab: TabLayout.Tab?) {}
-        })
+            // 다음 탭이 존재하는 경우에만 선택
+            if (currentTabIndex < binding.tlMainOptionTab.tabCount - 1) {
+                val nextTabIndex = currentTabIndex + 1
+                binding.tlMainOptionTab.getTabAt(nextTabIndex)?.select()
+
+                val tabName = binding.tlMainOptionTab.getTabAt(nextTabIndex)?.text?.replace(
+                    Regex("^\\d+\\s"),
+                    ""
+                ) ?: "Unknown"
+                carViewModel.setCurrentComponentName(tabName)
+
+                when (tabName) {
+                    OPTION_SELECTION -> handleOptionSelectionTab()
+                    else -> handleDefaultTab()
+                }
+            }
+        }
     }
 
     // 선택 옵션 탭이 선택되었을 때 처리.
@@ -292,65 +322,6 @@ class CarCustomizationFragment : Fragment() {
             binding.fragmentEstimate.ivParticle.startAnimation(animationSet)
         }
     }
-
-
-    private fun toggleButton() {
-        binding.fragmentEstimate.btnExterior.setOnClickListener {
-            binding.fragmentEstimate.ivEstimateDone.setImageResource(R.drawable.img_trim_leblanc)
-            binding.fragmentEstimate.btnExterior.setBackgroundColor(
-                ContextCompat.getColor(
-                    requireContext(),
-                    R.color.main_hyundai_blue
-                )
-            )
-            binding.fragmentEstimate.btnExterior.setTextColor(
-                ContextCompat.getColor(
-                    requireContext(),
-                    R.color.white
-                )
-            )
-            binding.fragmentEstimate.btnInterior.setBackgroundColor(
-                ContextCompat.getColor(
-                    requireContext(),
-                    R.color.cool_grey_001
-                )
-            )
-            binding.fragmentEstimate.btnInterior.setTextColor(
-                ContextCompat.getColor(
-                    requireContext(),
-                    R.color.cool_grey_black
-                )
-            )
-        }
-        binding.fragmentEstimate.btnInterior.setOnClickListener {
-            binding.fragmentEstimate.ivEstimateDone.setImageResource(R.drawable.img_test_make_car_05)
-            binding.fragmentEstimate.btnExterior.setBackgroundColor(
-                ContextCompat.getColor(
-                    requireContext(),
-                    R.color.cool_grey_001
-                )
-            )
-            binding.fragmentEstimate.btnExterior.setTextColor(
-                ContextCompat.getColor(
-                    requireContext(),
-                    R.color.cool_grey_black
-                )
-            )
-            binding.fragmentEstimate.btnInterior.setBackgroundColor(
-                ContextCompat.getColor(
-                    requireContext(),
-                    R.color.main_hyundai_blue
-                )
-            )
-            binding.fragmentEstimate.btnInterior.setTextColor(
-                ContextCompat.getColor(
-                    requireContext(),
-                    R.color.white
-                )
-            )
-        }
-    }
-
 
     override fun onDestroyView() {
         super.onDestroyView()

--- a/android/app/src/main/java/com/youngcha/ohmycarset/ui/fragment/CarCustomizationFragment.kt
+++ b/android/app/src/main/java/com/youngcha/ohmycarset/ui/fragment/CarCustomizationFragment.kt
@@ -11,6 +11,7 @@ import android.view.animation.AnimationSet
 import android.view.animation.AnimationUtils
 import android.widget.LinearLayout
 import android.widget.TextView
+import androidx.core.content.ContentProviderCompat.requireContext
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
@@ -38,7 +39,6 @@ class CarCustomizationFragment : Fragment() {
     private val binding get() = _binding ?: throw IllegalStateException("Binding is null.")
 
     private val carViewModel: CarCustomizationViewModel by viewModels()
-    private var currentTabIndex = 0
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -60,11 +60,11 @@ class CarCustomizationFragment : Fragment() {
             vpOptionContainer.adapter = CarOptionPagerAdapter(carViewModel)
             attachTabLayoutMediator()
             setupRecyclerView()
-            setupMainTabSelectionListener()
             setupSubTabs()
             observeViewModel()
             setupListener()
         }
+        binding.vMainTabLayoutOverlay.setOnTouchListener { _, _ -> true }
     }
 
     @SuppressLint("ClickableViewAccessibility")
@@ -111,26 +111,29 @@ class CarCustomizationFragment : Fragment() {
 
     private fun observeViewModel() {
         carViewModel.selectedCar.observe(viewLifecycleOwner) { car ->
-            carViewModel.updateTabInformation(car)
+            carViewModel.updateTabInfo(car)
+            val firstKey = car.mainOptions.first().keys.firstOrNull()
+            carViewModel.setCurrentComponentName(firstKey!!)
         }
 
         carViewModel.subOptionViewType.observe(viewLifecycleOwner) {
-            updateDataContainerWithCurrentTab()
+            carViewModel.updateDataContainer()
         }
 
+        // 메인 탭 옵션 리스트 (ex: 파워 트레인 -> [디젤], [가솔린])
         carViewModel.currentOptionList.observe(viewLifecycleOwner) { optionList ->
             handleOptionListUpdates(optionList)
         }
 
-        carViewModel.mainOptionsTabs.observe(viewLifecycleOwner) { tabs ->
+        carViewModel.currentMainTabs.observe(viewLifecycleOwner) { tabs ->
             tabs.forEach { tabName ->
                 binding.tlMainOptionTab.addTab(binding.tlMainOptionTab.newTab().setText(tabName))
             }
         }
 
-        carViewModel.additionalTabs.observe(viewLifecycleOwner) { tabs ->
+        carViewModel.currentSubTabs.observe(viewLifecycleOwner) {tabs ->
             tabs.forEach { tabName ->
-                binding.tlMainOptionTab.addTab(binding.tlMainOptionTab.newTab().setText(tabName))
+                binding.tlSubOptionTab.addTab(createCustomTab(tabName))
             }
         }
 
@@ -139,17 +142,31 @@ class CarCustomizationFragment : Fragment() {
                 particleAnimation()
             }
         }
-    }
 
-    private fun updateDataContainerWithCurrentTab() {
-        val currentTab = binding.tlSubOptionTab.getTabAt(currentTabIndex)
-        currentTab?.let { tab ->
-            updateDataContainer(tab)
+        carViewModel.displayOnRecyclerViewOnViewPager.observe(viewLifecycleOwner) { mode ->
+            val tabName = carViewModel.currentTabName.value // currentTabName -> main tab + sub tab
+            carViewModel.getOptionInfoByKey(tabName!!).let {
+                when (mode) {
+                    0 -> it?.let { it1 -> displayOnRecyclerView(it1, tabName) }
+                    1 -> it?.let { it1 -> displayOnViewPager(it1, tabName) }
+                    else -> {}
+                }
+            }
+            attachTabLayoutMediator()
+        }
+
+        carViewModel.currentTabPosition.observe(viewLifecycleOwner) {
+            binding.tlMainOptionTab.getTabAt(it)?.select()
+        }
+
+        carViewModel.customizedParts.observe(viewLifecycleOwner) {
+            Log.d("로그1", it.toString())
         }
     }
 
     // 현재 선택한 탭의 옵션 리스트를 ViewPager에 연결
     private fun handleOptionListUpdates(optionList: List<OptionInfo>) {
+        // optionList.size가 2이상이라면 viewpager에 데이터가 보여야함
         if (optionList.size <= 2) {
             (binding.vpOptionContainer.adapter as? CarOptionPagerAdapter)?.clearOptions()
             return
@@ -168,64 +185,6 @@ class CarCustomizationFragment : Fragment() {
         binding.vpOptionContainer.setCurrentItem(position, false)
     }
 
-
-    private fun setupMainTabSelectionListener() {
-        binding.vMainTabLayoutOverlay.setOnTouchListener { _, _ -> true }
-
-        binding.btnPrev.setOnClickListener {
-            val currentTabIndex = binding.tlMainOptionTab.selectedTabPosition
-
-            // 이전 탭이 존재하는 경우에만 선택
-            if (currentTabIndex > 0) {
-                val prevTabIndex = currentTabIndex - 1
-                binding.tlMainOptionTab.getTabAt(prevTabIndex)?.select()
-
-                val tabName = binding.tlMainOptionTab.getTabAt(prevTabIndex)?.text?.replace(
-                    Regex("^\\d+\\s"),
-                    ""
-                ) ?: "Unknown"
-                carViewModel.setCurrentComponentName(tabName)
-
-                when (tabName) {
-                    OPTION_SELECTION -> handleOptionSelectionTab()
-                    else -> handleDefaultTab()
-                }
-            }
-        }
-
-        binding.btnNext.setOnClickListener {
-            val currentTabIndex = binding.tlMainOptionTab.selectedTabPosition
-
-            // 다음 탭이 존재하는 경우에만 선택
-            if (currentTabIndex < binding.tlMainOptionTab.tabCount - 1) {
-                val nextTabIndex = currentTabIndex + 1
-                binding.tlMainOptionTab.getTabAt(nextTabIndex)?.select()
-
-                val tabName = binding.tlMainOptionTab.getTabAt(nextTabIndex)?.text?.replace(
-                    Regex("^\\d+\\s"),
-                    ""
-                ) ?: "Unknown"
-                carViewModel.setCurrentComponentName(tabName)
-
-                when (tabName) {
-                    OPTION_SELECTION -> handleOptionSelectionTab()
-                    else -> handleDefaultTab()
-                }
-            }
-        }
-    }
-
-    // 선택 옵션 탭이 선택되었을 때 처리.
-    private fun handleOptionSelectionTab() {
-        binding.tlSubOptionTab.getTabAt(0)?.let { updateDataContainer(it) }
-        carViewModel.setOptionSelectionTabValues()
-    }
-
-    // 기본 탭이 선택되었을 때 처리.
-    private fun handleDefaultTab() {
-        carViewModel.setDefaultTabValues()
-    }
-
     private fun setupRecyclerView() {
         // LinearLayoutManager 사용하여 수직 방향의 리스트로 설정
         val linearLayoutManager = LinearLayoutManager(requireContext())
@@ -239,16 +198,16 @@ class CarCustomizationFragment : Fragment() {
     }
 
     private fun setupSubTabs() {
-        setupSubOptionTabs()
-        addTabSelectedListener()
-    }
+        // 옵션 선택에서 sub tab이 클릭되었을때
+        binding.tlSubOptionTab.addOnTabSelectedListener(object : TabLayout.OnTabSelectedListener {
+            override fun onTabSelected(tab: TabLayout.Tab) {
+                carViewModel.currentSubTabPosition.value = tab.position
+                carViewModel.updateDataContainer()
+            }
+            override fun onTabUnselected(tab: TabLayout.Tab) {}
 
-    private fun setupSubOptionTabs() {
-        val tabNames = carViewModel.getSubOptionKeys()
-
-        for (name in tabNames) {
-            binding.tlSubOptionTab.addTab(createCustomTab(name))
-        }
+            override fun onTabReselected(tab: TabLayout.Tab) {}
+        })
     }
 
     private fun createCustomTab(name: String): TabLayout.Tab {
@@ -259,45 +218,15 @@ class CarCustomizationFragment : Fragment() {
         return tab
     }
 
-    private fun addTabSelectedListener() {
-        binding.tlSubOptionTab.addOnTabSelectedListener(object : TabLayout.OnTabSelectedListener {
-            override fun onTabSelected(tab: TabLayout.Tab) {
-                currentTabIndex = tab.position
-                updateDataContainer(tab)
-            }
 
-            override fun onTabUnselected(tab: TabLayout.Tab) {}
-
-            override fun onTabReselected(tab: TabLayout.Tab) {}
-        })
-    }
-
-    private fun updateDataContainer(tab: TabLayout.Tab) {
-        val tabName = getTabName(tab)
-
-        val optionInfos = carViewModel.getOptionInfoByKey(tabName)
-        if (optionInfos != null) {
-            if (carViewModel.subOptionButtonVisible.value == 0) {
-                displayOnRecyclerView(optionInfos, tabName)
-            } else {
-                displayOnViewPager(optionInfos, tabName)
-            }
-        }
-
-        TabLayoutMediator(binding.tbOptionIndicator, binding.vpOptionContainer) { _, _ -> }.attach()
-    }
-
-    private fun getTabName(tab: TabLayout.Tab): String {
-        val customView = tab.customView
-        return customView?.findViewById<TextView>(R.id.tv_tab_name)?.text?.toString() ?: ""
-    }
-
+    // sub option 상태에서만 가능
     private fun displayOnRecyclerView(optionInfos: List<OptionInfo>, tabName: String) {
         val adapter = CarOptionPagerAdapter(carViewModel)
         binding.rvSubOptionList.adapter = adapter
         adapter.setOptions(optionInfos, OPTION_SELECTION, tabName, false, carViewModel.currentType.value)
     }
 
+    // main & sub 전부 가능
     private fun displayOnViewPager(optionInfos: List<OptionInfo>, tabName: String) {
         val adapter = CarOptionPagerAdapter(carViewModel)
         binding.vpOptionContainer.adapter = adapter

--- a/android/app/src/main/java/com/youngcha/ohmycarset/viewmodel/CarCustomizationViewModel.kt
+++ b/android/app/src/main/java/com/youngcha/ohmycarset/viewmodel/CarCustomizationViewModel.kt
@@ -19,43 +19,34 @@ import com.youngcha.ohmycarset.util.OPTION_SELECTION
 
 class CarCustomizationViewModel : ViewModel() {
 
-    // 사용자가 선택한 자동차
+    // 자동차 정보 관련 변수들
+    // 관련된 변수: selectedCar, currentComponentName, customizedParts
     private val _selectedCar = MutableLiveData<Car>()
     val selectedCar: LiveData<Car> = _selectedCar
 
-    // 현재 선택한 자동차 이름 == _selectedCar.value?.name
     private val _currentComponentName = MutableLiveData<String>()
     val currentComponentName: LiveData<String> = _currentComponentName
 
-    // 내가 커스터마이징 하고 있는 자동차
     private val _customizedParts = MutableLiveData<List<Map<String, List<OptionInfo>>>>()
     val customizedParts: LiveData<List<Map<String, List<OptionInfo>>>> = _customizedParts
 
+    // 선택 모드 관련 변수
+    // 관련된 변수: currentType
     private val _currentType = MutableLiveData<String>("SelfMode")
     val currentType: LiveData<String> = _currentType
 
-    /*
-    파워트레인, 구동 방식, 바디 타입등 선택할 수 있는 옵션이 2개이하라면 Horizontal Two Button 으로 선택 가능
-    그 중 componentOption1Visibility는 왼쪽 버튼이 선택 됐을 경우 버튼 layout 변경 (ex: background....)
-         componentOption2Visibility는 오른쪽 버튼 선택 됐을 경우 처리
-
-    옵션이 2개 이상이라면 스와이프 형식으로 옵션 선택 ViewPager사용
-    tlOptionVisibility -> ViewPager2 가시성 제어
-    만약 tlOptionVisibility가 1이라면 ViewPager보이고 2개 버튼 표시되는 View 가리기
-    */
+    // 옵션 선택 UI 관련 변수들
+    // 관련된 변수: componentOption1Visibility, componentOption2Visibility, horizontalButtonVisible, swipeButtonVisible, subOptionButtonVisible, subOptionViewTypeChangeButton, subOptionViewType
     val componentOption1Visibility = MutableLiveData<Int>()
     val componentOption2Visibility = MutableLiveData<Int>()
-
-    val currentOptionList = MediatorLiveData<List<OptionInfo>>()
-
-    val horizontalButtonVisible = MutableLiveData<Int>(0) // 가로 버튼 visible
-    val swipeButtonVisible = MutableLiveData<Int>(0) // viewpager visible
-    val subOptionButtonVisible = MutableLiveData<Int>(1) // subOption: 1이면 mainImage 보이게 0이면 안보이게
-    val subOptionViewTypeChangeButton =
-        MutableLiveData<Int>(0) // sub option viewpager <-> recyclerview 전환 이미지
+    val horizontalButtonVisible = MutableLiveData<Int>(0)
+    val swipeButtonVisible = MutableLiveData<Int>(0)
+    val subOptionButtonVisible = MutableLiveData<Int>(1)
+    val subOptionViewTypeChangeButton = MutableLiveData<Int>(0)
     val subOptionViewType = MutableLiveData<Int>(0)
 
-    // Tab 관련 변수
+    // 탭 UI 관련 변수들
+    // 관련된 변수: currentTabName, currentTabPosition, currentSubTabPosition, currentMainTabs, currentSubTabs
     val currentTabName = MutableLiveData<String>()
     private val _currentTabPosition =  MutableLiveData<Int>(0)
     val currentTabPosition: LiveData<Int> = _currentTabPosition
@@ -64,13 +55,21 @@ class CarCustomizationViewModel : ViewModel() {
     private val _currentSubTabs = MutableLiveData<List<String>>()
     val currentSubTabs: LiveData<List<String>> = _currentSubTabs
 
+    // 뷰페이지 및 리사이클러뷰 표시 관련 변수
+    // 관련된 변수: displayOnRecyclerViewOnViewPager
     private val _displayOnRecyclerViewAndViewPager = MutableLiveData<Int>(0)
     val displayOnRecyclerViewOnViewPager: LiveData<Int> = _displayOnRecyclerViewAndViewPager
 
+    // 추정 보기 관련 변수
+    // 관련된 변수: estimateViewVisible
     private val _estimateViewVisible = MutableLiveData<Int>(0)
     val estimateViewVisible: LiveData<Int> = _estimateViewVisible
 
+    // 외관 버튼 변화 관련 변수
+    // 관련된 변수: exteriorButtonChange
     val exteriorButtonChange = MutableLiveData<Int>(1)
+
+    val currentOptionList = MediatorLiveData<List<OptionInfo>>()
 
     // init block
     init {

--- a/android/app/src/main/java/com/youngcha/ohmycarset/viewmodel/CarCustomizationViewModel.kt
+++ b/android/app/src/main/java/com/youngcha/ohmycarset/viewmodel/CarCustomizationViewModel.kt
@@ -18,7 +18,6 @@ import com.youngcha.ohmycarset.model.car.OptionInfo
 import com.youngcha.ohmycarset.util.OPTION_SELECTION
 
 class CarCustomizationViewModel : ViewModel() {
-
     // 자동차 정보 관련 변수들
     // 관련된 변수: selectedCar, currentComponentName, customizedParts
     private val _selectedCar = MutableLiveData<Car>()
@@ -71,7 +70,8 @@ class CarCustomizationViewModel : ViewModel() {
 
     val currentOptionList = MediatorLiveData<List<OptionInfo>>()
 
-    // init block
+
+    // 초기화 블록
     init {
         loadCarData("팰리세이드")
         _currentComponentName.value = selectedCar.value?.mainOptions?.get(0)?.keys?.first()
@@ -99,9 +99,18 @@ class CarCustomizationViewModel : ViewModel() {
         _currentSubTabs.value = getSubOptionKeys()
     }
 
+    // --- UI 업데이트 관련 함수 ---
+
+    /**
+     * 견적 색상 버튼 업데이트
+     */
     fun updateEstimateColorButton(view:View) {
         exteriorButtonChange.value = if(exteriorButtonChange.value==1) 0 else 1
     }
+
+    /**
+     * 현재 타입 업데이트
+     */
     fun updateCurrentType(currentType: String) {
         _currentType.value = currentType
         _currentTabPosition.value = 0
@@ -111,6 +120,9 @@ class CarCustomizationViewModel : ViewModel() {
         setCurrentComponentName(currentTabName.value!!)
     }
 
+    /**
+     * 탭 정보 업데이트
+     */
     fun updateTabInfo(car: Car) {
         val mainOptions = car.mainOptions[0].keys.mapIndexed { index, carOptionKey ->
             "${String.format("%02d", index + 1)} $carOptionKey"
@@ -124,6 +136,9 @@ class CarCustomizationViewModel : ViewModel() {
         }
     }
 
+    /**
+     * 탭 변경 핸들러
+     */
     fun handleTabChange(increment: Int) {
         val currentTabIndex = currentTabPosition.value ?: 0
         val nextTabIndex = currentTabIndex + increment
@@ -141,17 +156,19 @@ class CarCustomizationViewModel : ViewModel() {
         }
     }
 
-    // 메인 탭이 선택되었을 때 처리.
-    private fun handleMainTab() {
-        setDefaultTabValues()
+    /**
+     * 서브옵션 변경 핸들러
+     */
+    fun onSubOptionChanged(view: View) {
+        subOptionButtonVisible.value = if (subOptionButtonVisible.value == 1) 0 else 1
+        subOptionViewType.value = if (subOptionViewType.value == 1) 0 else 1
     }
 
-    // 선택 옵션 탭이 선택되었을 때 처리.
-    private fun handleSubTab() {
-        updateDataContainer()
-        setOptionSelectionTabValues()
-    }
+// --- 데이터 설정 및 조회 관련 함수 ---
 
+    /**
+     * 현재 컴포넌트 이름 설정
+     */
     fun setCurrentComponentName(componentName: String) {
         _currentComponentName.value = componentName
 
@@ -174,15 +191,9 @@ class CarCustomizationViewModel : ViewModel() {
         }
     }
 
-    private fun getSubOptionKeys(): List<String> {
-        val keys = mutableListOf<String>()
-        val car = _selectedCar.value
-        car?.subOptions?.forEach { map ->
-            keys.addAll(map.keys)
-        }
-        return keys
-    }
-
+    /**
+     * 키를 사용하여 서브옵션 정보 가져오기
+     */
     fun getOptionInfoByKey(key: String): List<OptionInfo>? {
         val car = _selectedCar.value
         car?.subOptions?.forEach { map ->
@@ -193,6 +204,9 @@ class CarCustomizationViewModel : ViewModel() {
         return null
     }
 
+    /**
+     * 자동차 컴포넌트 추가
+     */
     fun addCarComponents(
         componentName: String,
         option: OptionInfo,
@@ -227,6 +241,9 @@ class CarCustomizationViewModel : ViewModel() {
         _customizedParts.value = updatedList
     }
 
+    /**
+     * 자동차 컴포넌트 제거
+     */
     fun removeCarComponents(keyName: String, option: OptionInfo) {
         val updatedList = _customizedParts.value?.toMutableList() ?: return
         val index = updatedList.indexOfFirst { it.containsKey(keyName) }
@@ -248,6 +265,9 @@ class CarCustomizationViewModel : ViewModel() {
         }
     }
 
+    /**
+     * 선택된 옵션 조회
+     */
     fun isSelectedOptions(tabName: String): List<OptionInfo>? {
         /*
         val data = listOf(
@@ -273,6 +293,11 @@ class CarCustomizationViewModel : ViewModel() {
         return null
     }
 
+// --- 데이터 헬퍼 함수 ---
+
+    /**
+     * 이미 선택된 컴포넌트 처리
+     */
     private fun alreadySelectedComponent(componentName: String) {
         val car = _customizedParts.value ?: listOf()
         val index = car.indexOfFirst { it.containsKey(componentName) }
@@ -292,7 +317,59 @@ class CarCustomizationViewModel : ViewModel() {
             onComponentOption1Selected()
         }
     }
+    /**
+     * 데이터 컨테이너 업데이트
+     */
+    fun updateDataContainer() {
+        currentTabName.value = _currentSubTabs.value?.get(currentSubTabPosition.value!!)
+        _displayOnRecyclerViewAndViewPager.value = if (subOptionButtonVisible.value == 0) 0 else 1
+    }
 
+    /**
+     * 차량 데이터 로드
+     */
+    private fun loadCarData(carName: String) {
+        _selectedCar.value = createCarData(carName)
+    }
+
+    // --- 기타 헬퍼 함수 ---
+
+    /**
+     * 메인 탭 처리
+     */
+    private fun handleMainTab() {
+        setDefaultTabValues()
+    }
+
+    /**
+     * 서브 탭 처리
+     */
+    private fun handleSubTab() {
+        updateDataContainer()
+        setOptionSelectionTabValues()
+    }
+
+    /**
+     * 컴포넌트 옵션의 가시성 설정
+     */
+    private fun setComponentOptionVisibility(option1Visible: Int, option2Visible: Int) {
+        componentOption1Visibility.value = option1Visible
+        componentOption2Visibility.value = option2Visible
+    }
+
+    /**
+     * 컴포넌트 이름을 기반으로 옵션 조회
+     */
+    private fun getOptionsForComponent(componentName: String): List<OptionInfo>? {
+        return selectedCar.value?.mainOptions?.firstOrNull { it.containsKey(componentName) }
+            ?.get(componentName)
+    }
+
+    // --- 컴포넌트 옵션 선택 관련 함수 ---
+
+    /**
+     * 컴포넌트의 0번 인덱스 옵션을 선택했을 때의 처리 함수
+     */
     fun onComponentOption1Selected() {
         val componentName = _currentComponentName.value ?: return
         val option = getOption(componentName, 0) ?: return // 0번 인덱스 옵션 가져오기
@@ -300,55 +377,57 @@ class CarCustomizationViewModel : ViewModel() {
         setComponentOptionVisibility(1, 0)
     }
 
+    /**
+     * 컴포넌트의 1번 인덱스 옵션을 선택했을 때의 처리 함수
+     */
     fun onComponentOption2Selected() {
         val componentName = _currentComponentName.value ?: return
         val option = getOption(componentName, 1) ?: return // 1번 인덱스 옵션 가져오기
         addCarComponents(componentName, option)
         setComponentOptionVisibility(0, 1)
-
     }
 
-    private fun setComponentOptionVisibility(option1Visible: Int, option2Visible: Int) {
-        componentOption1Visibility.value = option1Visible
-        componentOption2Visibility.value = option2Visible
-    }
+    // --- 탭 및 뷰 설정 관련 함수 ---
 
-    fun onSubOptionChanged(view: View) {
-        subOptionButtonVisible.value = if (subOptionButtonVisible.value == 1) 0 else 1
-        subOptionViewType.value = if (subOptionViewType.value == 1) 0 else 1
-    }
-
+    /**
+     * 옵션 선택 탭 값 설정
+     */
     private fun setOptionSelectionTabValues() {
         subOptionViewTypeChangeButton.value = 1
         subOptionButtonVisible.value = 1
     }
 
-    private fun getOptionsForComponent(componentName: String): List<OptionInfo>? {
-        return selectedCar.value?.mainOptions?.firstOrNull { it.containsKey(componentName) }
-            ?.get(componentName)
-    }
-
-    private fun getOptionSize(componentName: String): Int {
-        return getOptionsForComponent(componentName)?.size ?: 0
-    }
-
-    fun getOption(componentName: String, index: Int): OptionInfo? {
-        return getOptionsForComponent(componentName)?.getOrNull(index)
-    }
-
+    /**
+     * 기본 탭 값 설정
+     */
     private fun setDefaultTabValues() {
         subOptionViewTypeChangeButton.value = 0 // viewpager <-> recyclerview
         subOptionButtonVisible.value = 1 // main Image visible
     }
 
-    // NEW
-    fun updateDataContainer() {
-        currentTabName.value = _currentSubTabs.value?.get(currentSubTabPosition.value!!)
-        _displayOnRecyclerViewAndViewPager.value = if (subOptionButtonVisible.value == 0) 0 else 1
+    // --- 옵션 정보 조회 관련 함수 ---
+
+    /**
+     * 컴포넌트 이름을 기반으로 해당 옵션의 크기(개수) 조회
+     */
+    private fun getOptionSize(componentName: String): Int {
+        return getOptionsForComponent(componentName)?.size ?: 0
     }
 
-    private fun loadCarData(carName: String) {
-        _selectedCar.value = createCarData(carName)
+    /**
+     * 컴포넌트 이름과 인덱스를 사용하여 특정 옵션 정보 조회
+     */
+    fun getOption(componentName: String, index: Int): OptionInfo? {
+        return getOptionsForComponent(componentName)?.getOrNull(index)
+    }
+
+    private fun getSubOptionKeys(): List<String> {
+        val keys = mutableListOf<String>()
+        val car = _selectedCar.value
+        car?.subOptions?.forEach { map ->
+            keys.addAll(map.keys)
+        }
+        return keys
     }
 
     // Test Data

--- a/android/app/src/main/res/layout/fragment_car_customization.xml
+++ b/android/app/src/main/res/layout/fragment_car_customization.xml
@@ -236,14 +236,14 @@
             layout="@layout/layout_bottom_sheet_estimate_summary"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            app:layout_constraintBottom_toTopOf="@id/button1"
+            app:layout_constraintBottom_toTopOf="@id/cl_button_container"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:viewModel="@{viewModel}" />
 
 
         <androidx.constraintlayout.widget.ConstraintLayout
-            android:id="@+id/button1"
+            android:id="@+id/cl_button_container"
             android:layout_width="match_parent"
             android:layout_height="108dp"
             android:background="@color/white"
@@ -258,11 +258,11 @@
                 android:layout_marginStart="20dp"
                 android:layout_marginTop="20dp"
                 android:fontFamily="@font/hyundai_sans_text_kr_regular"
-                android:text="총 견적금액"
+                android:text="@string/total_estimate_label"
                 android:textColor="@color/cool_grey_003"
                 android:textSize="14sp"
-                app:layout_constraintStart_toStartOf="@id/button1"
-                app:layout_constraintTop_toTopOf="@id/button1"
+                app:layout_constraintStart_toStartOf="@id/cl_button_container"
+                app:layout_constraintTop_toTopOf="@id/cl_button_container"
                 app:layout_constraintBottom_toTopOf="@id/tv_estimate_price_int"/>
 
             <TextView
@@ -275,7 +275,7 @@
                 android:text="42,000,000원"
                 android:textColor="@color/cool_grey_black"
                 android:textSize="22sp"
-                app:layout_constraintStart_toStartOf="@id/button1"
+                app:layout_constraintStart_toStartOf="@id/cl_button_container"
                 app:layout_constraintBottom_toBottomOf="parent"/>
 
             <TextView
@@ -285,7 +285,7 @@
                 android:background="@drawable/btn_main_style"
                 android:backgroundTint="@color/white"
                 android:fontFamily="@font/hyundai_sans_text_kr_regular"
-                android:text="이전"
+                android:text="@string/prev_button_label"
                 android:textAlignment="center"
                 android:textColor="@color/cool_grey_003"
                 android:textSize="14sp"
@@ -298,13 +298,12 @@
                 android:layout_width="87dp"
                 android:layout_height="50dp"
                 android:layout_marginEnd="27dp"
-
                 android:background="@drawable/btn_main_style"
                 android:fontFamily="@font/hyundai_sans_text_kr_regular"
-                android:text="선택완료"
-                app:layout_constraintEnd_toEndOf="@id/button1"
-                app:layout_constraintBottom_toBottomOf="@id/button1"
-                app:layout_constraintTop_toTopOf="@id/button1"
+                android:text="@string/selection_complete_button_label"
+                app:layout_constraintEnd_toEndOf="@id/cl_button_container"
+                app:layout_constraintBottom_toBottomOf="@id/cl_button_container"
+                app:layout_constraintTop_toTopOf="@id/cl_button_container"
                 android:textColor="@color/white"
                 android:textSize="14sp" />
 

--- a/android/app/src/main/res/layout/fragment_car_customization.xml
+++ b/android/app/src/main/res/layout/fragment_car_customization.xml
@@ -43,6 +43,19 @@
             app:tabTextAppearance="@style/MyCustomTabText"
             app:tabTextColor="@color/cool_grey_002" />
 
+        <View
+            android:id="@+id/v_main_tab_layout_overlay"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:layout_alignParentTop="true"
+            android:layout_alignParentBottom="true"
+            android:layout_alignParentStart="true"
+            android:layout_alignParentEnd="true"
+            app:layout_constraintTop_toTopOf="@id/tl_main_option_tab"
+            app:layout_constraintBottom_toBottomOf="@id/tl_main_option_tab"
+            app:layout_constraintStart_toStartOf="@id/tl_main_option_tab"
+            app:layout_constraintEnd_toEndOf="@id/tl_main_option_tab" />
+
         <ImageView
             android:id="@+id/iv_main_img"
             android:layout_width="match_parent"
@@ -261,9 +274,9 @@
                 android:text="@string/total_estimate_label"
                 android:textColor="@color/cool_grey_003"
                 android:textSize="14sp"
+                app:layout_constraintBottom_toTopOf="@id/tv_estimate_price_int"
                 app:layout_constraintStart_toStartOf="@id/cl_button_container"
-                app:layout_constraintTop_toTopOf="@id/cl_button_container"
-                app:layout_constraintBottom_toTopOf="@id/tv_estimate_price_int"/>
+                app:layout_constraintTop_toTopOf="@id/cl_button_container" />
 
             <TextView
                 android:id="@+id/tv_estimate_price"
@@ -275,8 +288,8 @@
                 android:text="42,000,000원"
                 android:textColor="@color/cool_grey_black"
                 android:textSize="22sp"
-                app:layout_constraintStart_toStartOf="@id/cl_button_container"
-                app:layout_constraintBottom_toBottomOf="parent"/>
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintStart_toStartOf="@id/cl_button_container" />
 
             <TextView
                 android:id="@+id/btn_prev"
@@ -289,9 +302,9 @@
                 android:textAlignment="center"
                 android:textColor="@color/cool_grey_003"
                 android:textSize="14sp"
-                app:layout_constraintTop_toTopOf="@id/btn_next"
                 app:layout_constraintBottom_toBottomOf="@id/btn_next"
-                app:layout_constraintEnd_toStartOf="@id/btn_next"/>
+                app:layout_constraintEnd_toStartOf="@id/btn_next"
+                app:layout_constraintTop_toTopOf="@id/btn_next" />
 
             <androidx.appcompat.widget.AppCompatButton
                 android:id="@+id/btn_next"
@@ -301,24 +314,24 @@
                 android:background="@drawable/btn_main_style"
                 android:fontFamily="@font/hyundai_sans_text_kr_regular"
                 android:text="@string/selection_complete_button_label"
-                app:layout_constraintEnd_toEndOf="@id/cl_button_container"
-                app:layout_constraintBottom_toBottomOf="@id/cl_button_container"
-                app:layout_constraintTop_toTopOf="@id/cl_button_container"
                 android:textColor="@color/white"
-                android:textSize="14sp" />
+                android:textSize="14sp"
+                app:layout_constraintBottom_toBottomOf="@id/cl_button_container"
+                app:layout_constraintEnd_toEndOf="@id/cl_button_container"
+                app:layout_constraintTop_toTopOf="@id/cl_button_container" />
 
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+            <include
+                android:id="@+id/fragment_estimate"
+                layout="@layout/layout_estimate"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:visibility="@{viewModel.estimateViewVisible == 1 ?View.VISIBLE:View.INVISIBLE}"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/tl_main_option_tab"
+                app:viewModel="@{viewModel}" />
     </androidx.constraintlayout.widget.ConstraintLayout>
 
-    <include
-        android:id="@+id/fragment_estimate"
-        layout="@layout/layout_estimate"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:visibility="@{viewModel.estimateViewVisible == 1 ?View.VISIBLE:View.INVISIBLE}"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/tl_main_option_tab"
-        app:viewModel="@{viewModel}" />
-</androidx.constraintlayout.widget.ConstraintLayout>
-
-    </layout>
+</layout>

--- a/android/app/src/main/res/layout/fragment_car_customization.xml
+++ b/android/app/src/main/res/layout/fragment_car_customization.xml
@@ -302,6 +302,7 @@
                 android:textAlignment="center"
                 android:textColor="@color/cool_grey_003"
                 android:textSize="14sp"
+                android:onClick="@{() -> viewModel.handleTabChange(-1)}"
                 app:layout_constraintBottom_toBottomOf="@id/btn_next"
                 app:layout_constraintEnd_toStartOf="@id/btn_next"
                 app:layout_constraintTop_toTopOf="@id/btn_next" />
@@ -316,6 +317,7 @@
                 android:text="@string/selection_complete_button_label"
                 android:textColor="@color/white"
                 android:textSize="14sp"
+                android:onClick="@{() -> viewModel.handleTabChange(1)}"
                 app:layout_constraintBottom_toBottomOf="@id/cl_button_container"
                 app:layout_constraintEnd_toEndOf="@id/cl_button_container"
                 app:layout_constraintTop_toTopOf="@id/cl_button_container" />

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -133,6 +133,9 @@
     <string name="request_driving">시승 신청하기</string>
     <string name="share">공유하기</string>
     <string name="save">저장하기</string>
+    <string name="total_estimate_label">총 견적금액</string>
+    <string name="prev_button_label">이전</string>
+    <string name="selection_complete_button_label">선택완료</string>
 
 
 </resources>


### PR DESCRIPTION
## 📕 요약

closed #163

## 📗 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] 탭 레이아웃 이동 막기
- [x] 탭 초기에 기본 값 저장하기
- [x] 이전 | 선택 버튼 기능 구현
- [x] Fragment 로직 코드 -> ViewModel 이동   

## 📘 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- Fragment에서 처리했던 로직 중 ViewModel로 옮길 수 있는 부분은 옮기고, ViewModel 코드 정리했습니다.
