### PR TITLE
[FE] 404 페이지 구현

### DIFF
--- a/client/src/pages/error/constant.tsx
+++ b/client/src/pages/error/constant.tsx
@@ -1,0 +1,21 @@
+export const ERROR_CONTENT = {
+  404: {
+    title: '페이지를 찾을 수 없습니다.',
+    content: (
+      <h2 className="body1 mb-12px">
+        주소를 잘못 입력했거나 페이지가 이동했을 수 있습니다.
+      </h2>
+    ),
+  },
+  default: {
+    title: '현대닷컴 접속이 원활하지 않습니다.',
+    content: (
+      <>
+        <h2 className="body1">
+          일시적인 현상이거나, 네트워크 문제일 수 있으니
+        </h2>
+        <h2 className="body1 mb-12px">잠시 후 다시 시도해주세요.</h2>
+      </>
+    ),
+  },
+};

--- a/client/src/pages/error/index.tsx
+++ b/client/src/pages/error/index.tsx
@@ -2,8 +2,13 @@ import Header from '@/components/Header';
 import * as Icon from '@/assets/icons';
 import { Link } from 'react-router-dom';
 import Button from '@/components/Button';
+import getErrorContent from '@/utils/getErrorContent';
 
-function ErrorPage() {
+interface ErrorPageProps {
+  errorType?: string;
+}
+function ErrorPage({ errorType = 'default' }: ErrorPageProps) {
+  const errorContent = getErrorContent(errorType);
   return (
     <>
       <Header />
@@ -13,12 +18,9 @@ function ErrorPage() {
         </Link>
 
         <h1 className="font-medium font-hsans-head text-32px">
-          현대닷컴 접속이 원활하지 않습니다.
+          {errorContent.title}
         </h1>
-        <h2 className="body1">
-          일시적인 현상이거나, 네트워크 문제일 수 있으니
-        </h2>
-        <h2 className="body1 mb-12px">잠시 후 다시 시도해주세요.</h2>
+        {errorContent.content}
         <Link to="/">
           <Button>홈 으로</Button>
         </Link>

--- a/client/src/pages/error/index.tsx
+++ b/client/src/pages/error/index.tsx
@@ -1,0 +1,30 @@
+import Header from '@/components/Header';
+import * as Icon from '@/assets/icons';
+import { Link } from 'react-router-dom';
+import Button from '@/components/Button';
+
+function ErrorPage() {
+  return (
+    <>
+      <Header />
+      <div className="flex flex-col items-center justify-center h-full pt-80px min-w-768px gap-16px">
+        <Link to="/">
+          <Icon.HDLogo className="w-166px h-23px mb-16px" />
+        </Link>
+
+        <h1 className="font-medium font-hsans-head text-32px">
+          현대닷컴 접속이 원활하지 않습니다.
+        </h1>
+        <h2 className="body1">
+          일시적인 현상이거나, 네트워크 문제일 수 있으니
+        </h2>
+        <h2 className="body1 mb-12px">잠시 후 다시 시도해주세요.</h2>
+        <Link to="/">
+          <Button>홈 으로</Button>
+        </Link>
+      </div>
+    </>
+  );
+}
+
+export default ErrorPage;

--- a/client/src/router/index.tsx
+++ b/client/src/router/index.tsx
@@ -55,10 +55,11 @@ const router = createBrowserRouter([
         ],
       },
     ],
+    errorElement: <ErrorPage />,
   },
   {
     path: '*',
-    element: <ErrorPage />,
+    element: <ErrorPage errorType="404" />,
   },
 ]);
 

--- a/client/src/router/index.tsx
+++ b/client/src/router/index.tsx
@@ -4,6 +4,7 @@ import { Navigate, createBrowserRouter } from 'react-router-dom';
 import Guide from '@/pages/guide';
 import Making from '@/pages/making';
 import FullScreenLayout from '@/components/layout/FullScreenLayout';
+import ErrorPage from '@/pages/error';
 
 const router = createBrowserRouter([
   {
@@ -57,7 +58,7 @@ const router = createBrowserRouter([
   },
   {
     path: '*',
-    element: <div>404</div>,
+    element: <ErrorPage />,
   },
 ]);
 

--- a/client/src/utils/getErrorContent.ts
+++ b/client/src/utils/getErrorContent.ts
@@ -1,0 +1,12 @@
+import { ERROR_CONTENT } from '@/pages/error/constant';
+
+function getErrorContent(errorType: string) {
+  switch (errorType) {
+    case '404':
+      return ERROR_CONTENT[errorType];
+    default:
+      return ERROR_CONTENT['default'];
+  }
+}
+
+export default getErrorContent;


### PR DESCRIPTION
## 📕 요약

잘못된 URL 요청시 404 페이지 이동

### Issue
closed #201

### 서버 에러
<img width="1718" alt="스크린샷 2023-08-21 오후 6 21 45" src="https://github.com/softeerbootcamp-2nd/H8-YoungCha/assets/37887690/a614d296-d14a-4c08-9868-7955d1fc09b6">

### 404 URL 에러
<img width="1722" alt="스크린샷 2023-08-21 오후 6 21 12" src="https://github.com/softeerbootcamp-2nd/H8-YoungCha/assets/37887690/a120e3f4-4aee-4534-9233-561e9bb92c6f">

## 📗 작업 내용

- [x] 404 페이지 생성
- [x] API 에러 페이지 생성
