### PR TITLE
[BE] Self mode API 성능 개선

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -63,6 +63,7 @@ jacocoTestReport {
             fileTree(dir: it, excludes: [
                     "**/*Application*",
                     "**/common/dto/**",
+                    "**/common/config/**",
                     "**/common/exception/**"
             ])
         }))
@@ -83,6 +84,7 @@ tasks.jacocoTestCoverageVerification {
             excludes = [
                     "**/*Application*",
                     "**/common/dto/**",
+                    "**/common/config/**",
                     "**/common/exception/**"
             ]
         }

--- a/server/src/main/java/team/youngcha/common/config/CustomSerializer.java
+++ b/server/src/main/java/team/youngcha/common/config/CustomSerializer.java
@@ -1,0 +1,19 @@
+package team.youngcha.common.config;
+
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.type.TypeFactory;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+
+import java.util.Map;
+
+public class CustomSerializer extends Jackson2JsonRedisSerializer {
+    public CustomSerializer(Class type) {
+        super(type);
+    }
+
+    @Override
+    protected JavaType getJavaType(Class clazz) {
+        return TypeFactory.defaultInstance()
+                .constructMapType(Map.class, Long.class, Long.class);
+    }
+}

--- a/server/src/main/java/team/youngcha/common/config/RedisConfig.java
+++ b/server/src/main/java/team/youngcha/common/config/RedisConfig.java
@@ -5,6 +5,7 @@ import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 import org.springframework.data.redis.cache.RedisCacheConfiguration;
 import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
@@ -14,6 +15,7 @@ import org.springframework.data.redis.serializer.RedisSerializationContext;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 import java.time.Duration;
+import java.util.Map;
 
 @Configuration
 @EnableCaching
@@ -31,15 +33,38 @@ public class RedisConfig {
     }
 
     @Bean
-    public CacheManager cacheManager(RedisConnectionFactory cf) {
+    @Primary
+    public CacheManager defaultCacheManager(RedisConnectionFactory cf) {
         RedisCacheConfiguration redisCacheConfiguration = RedisCacheConfiguration
                 .defaultCacheConfig()
                 .serializeKeysWith(RedisSerializationContext.SerializationPair
                         .fromSerializer(new StringRedisSerializer()))
                 .serializeValuesWith(RedisSerializationContext.SerializationPair
                         .fromSerializer(new GenericJackson2JsonRedisSerializer()))
-                .entryTtl(Duration.ofMinutes(6L)); // 1시간 캐시
+                .entryTtl(Duration.ofMinutes(1L)); // 1시간 캐시
 
-        return RedisCacheManager.RedisCacheManagerBuilder.fromConnectionFactory(cf).cacheDefaults(redisCacheConfiguration).build();
+        return buildCacheManager(cf, redisCacheConfiguration);
+    }
+
+    // CustomSerializer를 사용해 Map<Long,Long>로 역직렬화
+    @Bean
+    public CacheManager mapCacheManager(RedisConnectionFactory cf) {
+        RedisCacheConfiguration redisCacheConfiguration = RedisCacheConfiguration
+                .defaultCacheConfig()
+                .serializeKeysWith(RedisSerializationContext.SerializationPair
+                        .fromSerializer(new StringRedisSerializer()))
+                .serializeValuesWith(RedisSerializationContext.SerializationPair
+                        .fromSerializer(new CustomSerializer(Map.class)))
+                .entryTtl(Duration.ofMinutes(1L)); // 1시간 캐시
+
+        return buildCacheManager(cf, redisCacheConfiguration);
+    }
+
+    private CacheManager buildCacheManager(RedisConnectionFactory cf,
+                                           RedisCacheConfiguration redisCacheConfiguration) {
+        return RedisCacheManager.RedisCacheManagerBuilder.
+                fromConnectionFactory(cf)
+                .cacheDefaults(redisCacheConfiguration)
+                .build();
     }
 }

--- a/server/src/main/java/team/youngcha/common/config/RedisConfig.java
+++ b/server/src/main/java/team/youngcha/common/config/RedisConfig.java
@@ -41,7 +41,7 @@ public class RedisConfig {
                         .fromSerializer(new StringRedisSerializer()))
                 .serializeValuesWith(RedisSerializationContext.SerializationPair
                         .fromSerializer(new GenericJackson2JsonRedisSerializer()))
-                .entryTtl(Duration.ofMinutes(1L)); // 1시간 캐시
+                .entryTtl(Duration.ofHours(1L)); // 1시간 캐시
 
         return buildCacheManager(cf, redisCacheConfiguration);
     }
@@ -55,7 +55,7 @@ public class RedisConfig {
                         .fromSerializer(new StringRedisSerializer()))
                 .serializeValuesWith(RedisSerializationContext.SerializationPair
                         .fromSerializer(new CustomSerializer(Map.class)))
-                .entryTtl(Duration.ofMinutes(1L)); // 1시간 캐시
+                .entryTtl(Duration.ofHours(1L)); // 1시간 캐시
 
         return buildCacheManager(cf, redisCacheConfiguration);
     }

--- a/server/src/main/java/team/youngcha/common/config/RedisConfig.java
+++ b/server/src/main/java/team/youngcha/common/config/RedisConfig.java
@@ -6,6 +6,7 @@ import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.Profile;
 import org.springframework.data.redis.cache.RedisCacheConfiguration;
 import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
@@ -17,6 +18,7 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
 import java.time.Duration;
 import java.util.Map;
 
+@Profile({"!test"})
 @Configuration
 @EnableCaching
 public class RedisConfig {

--- a/server/src/main/java/team/youngcha/domain/sell/repository/SellRepository.java
+++ b/server/src/main/java/team/youngcha/domain/sell/repository/SellRepository.java
@@ -31,7 +31,8 @@ public class SellRepository {
     }
 
     // 특정 트림의 특정 카테고리에 속하는 옵션의 연령대별 판매량을 조회
-    public Map<Long, Long> countOptionsByTrimIdAndAgeRange(Long trimId, RequiredCategory requiredCategory, AgeRange ageRange) {
+    public Map<Long, Long> countOptionsByTrimIdAndAgeRange(Long trimId, RequiredCategory requiredCategory,
+                                                           AgeRange ageRange) {
         String column = requiredCategory.getColumn() + "_id";
 
         String sql = "SELECT sell." + column + ", COUNT(*) AS count FROM sell " +
@@ -51,7 +52,8 @@ public class SellRepository {
     }
 
     // 특정 트림의 특정 카테고리에 속하는 옵션의 성별별 판매량을 조회
-    public Map<Long, Long> countOptionsByTrimIdAndGender(Long trimId, RequiredCategory requiredCategory, Gender gender) {
+    public Map<Long, Long> countOptionsByTrimIdAndGender(Long trimId, RequiredCategory requiredCategory,
+                                                         Gender gender) {
         String column = requiredCategory.getColumn() + "_id";
 
         String sql = "SELECT sell." + column + ", COUNT(*) AS count FROM sell " +
@@ -70,11 +72,13 @@ public class SellRepository {
     }
 
     // 특정 트림의 특정 카테고리에 속하는 옵션의 연령대 및 성별 별 판매량을 조회
-    public Map<Long, Long> countOptionsByTrimIdAndAgeRangeAndGender(Long trimId, RequiredCategory category, AgeRange ageRange, Gender gender) {
+    public Map<Long, Long> countOptionsByTrimIdAndAgeRangeAndGender(Long trimId, RequiredCategory category,
+                                                                    AgeRange ageRange, Gender gender) {
         String column = category.getColumn() + "_id";
 
         String sql = "SELECT sell." + column + ", COUNT(*) AS count FROM sell " +
-                "WHERE (sell.age >= :minAge AND sell.age <= :maxAge) AND sell.gender = :gender AND sell.trim_id = :trimId " +
+                "WHERE (sell.age >= :minAge AND sell.age <= :maxAge) " +
+                "AND sell.gender = :gender AND sell.trim_id = :trimId " +
                 "GROUP BY sell." + column;
 
         MapSqlParameterSource params = new MapSqlParameterSource();
@@ -106,7 +110,8 @@ public class SellRepository {
                 params);
     }
 
-    public Map<Long, Long> countByTrimIdAndExteriorColorForWheels(Long trimId, Long exteriorColorId, List<Long> wheelIds) {
+    public Map<Long, Long> countByTrimIdAndExteriorColorForWheels(Long trimId, Long exteriorColorId,
+                                                                  List<Long> wheelIds) {
         MapSqlParameterSource params = new MapSqlParameterSource();
         params.addValue("trimId", trimId);
         params.addValue("exteriorColorId", exteriorColorId);
@@ -114,7 +119,8 @@ public class SellRepository {
 
         List<Map<String, Object>> result = namedParameterJdbcTemplate.queryForList(
                 "SELECT wheel_id, COUNT(*) AS count FROM sell " +
-                        "WHERE trim_id = :trimId AND wheel_id IN (:wheelIds) AND exterior_color_id = :exteriorColorId " +
+                        "WHERE trim_id = :trimId " +
+                        "AND wheel_id IN (:wheelIds) AND exterior_color_id = :exteriorColorId " +
                         "GROUP BY wheel_id", params);
 
         return result.stream().collect(Collectors.toMap(

--- a/server/src/main/java/team/youngcha/domain/sell/repository/SellRepository.java
+++ b/server/src/main/java/team/youngcha/domain/sell/repository/SellRepository.java
@@ -103,8 +103,10 @@ public class SellRepository {
         params.addValue("optionIds", optionIds);
 
         String column = category.getColumn() + "_id";
+        String index = "idx_" + category.getColumn() + "_trim";
         return namedParameterJdbcTemplate.queryForList(
-                "select sell." + column + ", COUNT(*) as count from sell " +
+                "select sell." + column + ", COUNT(*) as count " +
+                        "from sell use index(" + index + ") " +
                         "where sell." + column + " in (:optionIds) and sell.trim_id = (:trimId) " +
                         "group by sell." + column,
                 params);

--- a/server/src/main/java/team/youngcha/domain/sell/repository/SellRepository.java
+++ b/server/src/main/java/team/youngcha/domain/sell/repository/SellRepository.java
@@ -19,7 +19,7 @@ public class SellRepository {
 
     private final NamedParameterJdbcTemplate namedParameterJdbcTemplate;
 
-    @Cacheable(value = "sell", cacheManager = "mapCacheManager")
+    @Cacheable(value = "Sell", cacheManager = "mapCacheManager")
     public Map<Long, Long> countOptionsByTrimIdAndContainOptionsIds(Long trimId, List<Long> optionIds,
                                                                     RequiredCategory category) {
         List<Map<String, Object>> results = querySellCounts(namedParameterJdbcTemplate, trimId,

--- a/server/src/main/java/team/youngcha/domain/sell/repository/SellSelectiveOptionRepository.java
+++ b/server/src/main/java/team/youngcha/domain/sell/repository/SellSelectiveOptionRepository.java
@@ -1,6 +1,7 @@
 package team.youngcha.domain.sell.repository;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Repository;
@@ -14,13 +15,16 @@ public class SellSelectiveOptionRepository {
 
     private final NamedParameterJdbcTemplate namedParameterJdbcTemplate;
 
+    @Cacheable(value = "SelectiveOption", cacheManager = "mapCacheManager")
     public Map<Long, Long> countByOptionIdForTrim(Long trimId) {
         MapSqlParameterSource params = new MapSqlParameterSource();
         params.addValue("trimId", trimId);
 
         String sql = "SELECT options_id, COUNT(*) AS options_count " +
-                "FROM sell_selective_options " +
-                "WHERE sell_id IN (SELECT id FROM sell WHERE trim_id = (:trimId)) " +
+                "FROM sell_selective_options AS sso use index(options_id)" +
+                "WHERE EXISTS(" +
+                "SELECT 1 FROM sell AS s " +
+                "WHERE sso.sell_id = s.id AND s.trim_id = (:trim_id))" +
                 "GROUP BY options_id";
 
         return namedParameterJdbcTemplate.queryForList(sql, params)

--- a/server/src/main/java/team/youngcha/domain/sell/repository/SellSelectiveOptionRepository.java
+++ b/server/src/main/java/team/youngcha/domain/sell/repository/SellSelectiveOptionRepository.java
@@ -24,7 +24,7 @@ public class SellSelectiveOptionRepository {
                 "FROM sell_selective_options AS sso use index(options_id)" +
                 "WHERE EXISTS(" +
                 "SELECT 1 FROM sell AS s " +
-                "WHERE sso.sell_id = s.id AND s.trim_id = (:trim_id))" +
+                "WHERE sso.sell_id = s.id AND s.trim_id = (:trimId))" +
                 "GROUP BY options_id";
 
         return namedParameterJdbcTemplate.queryForList(sql, params)

--- a/server/src/test/java/team/youngcha/domain/option/SelfOptionIntegrationTest.java
+++ b/server/src/test/java/team/youngcha/domain/option/SelfOptionIntegrationTest.java
@@ -32,7 +32,8 @@ public class SelfOptionIntegrationTest extends IntegrationTestBase {
     @DisplayName("트림의 파워 트레인 옵션을 셀프 모드로 조회한다.")
     void findSelfPowerTrain() {
         //given
-        jdbcTemplate.update("insert into sell (id, trim_id, engine_id, body_type_id, driving_system_id, exterior_color_id, interior_color_id, wheel_id, age, gender, create_date) " +
+        jdbcTemplate.update("insert into sell (id, trim_id, engine_id, body_type_id, driving_system_id, " +
+                "exterior_color_id, interior_color_id, wheel_id, age, gender, create_date) " +
                 "values (1, 2, 2, 1, 1, 1, 1, 1, 50, 0, '2023-01-01 12:12:12')," +
                 "(2, 2, 1, 1, 1, 1, 1, 1, 50, 0, '2023-01-01 12:12:12')," +
                 "(3, 2, 2, 1, 1, 1, 1, 1, 50, 0, '2023-01-01 12:12:12')," +
@@ -91,7 +92,8 @@ public class SelfOptionIntegrationTest extends IntegrationTestBase {
     @DisplayName("트림의 구동 방식 옵션을 셀프 모드로 조회한다.")
     void findSelfDrivingSystem() {
         //given
-        jdbcTemplate.update("insert into sell (id, trim_id, engine_id, body_type_id, driving_system_id, exterior_color_id, interior_color_id, wheel_id, age, gender, create_date) " +
+        jdbcTemplate.update("insert into sell (id, trim_id, engine_id, body_type_id, driving_system_id, " +
+                "exterior_color_id, interior_color_id, wheel_id, age, gender, create_date) " +
                 "values (1, 2, 1, 1, 3, 1, 1, 1, 50, 0, '2023-01-01 12:12:12')," +
                 "(2, 2, 1, 1, 4, 1, 1, 1, 50, 0, '2023-01-01 12:12:12')," +
                 "(3, 2, 1, 1, 3, 1, 1, 1, 50, 0, '2023-01-01 12:12:12')," +
@@ -139,7 +141,8 @@ public class SelfOptionIntegrationTest extends IntegrationTestBase {
     @DisplayName("트림의 바디 타입 옵션을 셀프 모드로 조회한다.")
     void findSelfBodyType() {
         //given
-        jdbcTemplate.update("insert into sell (id, trim_id, engine_id, body_type_id, driving_system_id, exterior_color_id, interior_color_id, wheel_id, age, gender, create_date) " +
+        jdbcTemplate.update("insert into sell (id, trim_id, engine_id, body_type_id, driving_system_id, " +
+                "exterior_color_id, interior_color_id, wheel_id, age, gender, create_date) " +
                 "values (1, 2, 1, 6, 1, 1, 1, 1, 50, 0, '2023-01-01 12:12:12')," +
                 "(2, 2, 1, 5, 1, 1, 1, 1, 50, 0, '2023-01-01 12:12:12')," +
                 "(3, 2, 1, 5, 1, 1, 1, 1, 50, 0, '2023-01-01 12:12:12')," +
@@ -188,7 +191,8 @@ public class SelfOptionIntegrationTest extends IntegrationTestBase {
     @DisplayName("트림의 외장 색상 옵션을 셀프 모드로 조회한다.")
     void findSelfExteriorColor() {
         //given
-        jdbcTemplate.update("insert into sell (id, trim_id, engine_id, body_type_id, driving_system_id, exterior_color_id, interior_color_id, wheel_id, age, gender, create_date) " +
+        jdbcTemplate.update("insert into sell (id, trim_id, engine_id, body_type_id, driving_system_id, " +
+                "exterior_color_id, interior_color_id, wheel_id, age, gender, create_date) " +
                 "values (1, 2, 1, 1, 1, 7, 1, 1, 50, 0, '2023-01-01 12:12:12')," +
                 "(2, 2, 1, 1, 1, 10, 1, 1, 50, 0, '2023-01-01 12:12:12')," +
                 "(3, 2, 1, 1, 1, 10, 1, 1, 50, 0, '2023-01-01 12:12:12')," +
@@ -274,7 +278,8 @@ public class SelfOptionIntegrationTest extends IntegrationTestBase {
     @DisplayName("트림의 내장 색상 옵션을 셀프 모드로 조회한다.")
     void findSelfInteriorColor() {
         //given
-        jdbcTemplate.update("insert into sell (id, trim_id, engine_id, body_type_id, driving_system_id, exterior_color_id, interior_color_id, wheel_id, age, gender, create_date) " +
+        jdbcTemplate.update("insert into sell (id, trim_id, engine_id, body_type_id, driving_system_id, " +
+                "exterior_color_id, interior_color_id, wheel_id, age, gender, create_date) " +
                 "values (1, 2, 1, 1, 1, 1, 13, 1, 50, 0, '2023-01-01 12:12:12')," +
                 "(2, 2, 1, 1, 1, 1, 14, 1, 50, 0, '2023-01-01 12:12:12')," +
                 "(3, 2, 1, 1, 1, 1, 13, 1, 50, 0, '2023-01-01 12:12:12')," +
@@ -316,7 +321,8 @@ public class SelfOptionIntegrationTest extends IntegrationTestBase {
         assertResponseAndExpected(response, List.of(black, gray));
     }
 
-    private void assertResponseAndExpected(ExtractableResponse<Response> response, List<FindSelfOptionResponse> expectedResponses) {
+    private void assertResponseAndExpected(ExtractableResponse<Response> response,
+                                           List<FindSelfOptionResponse> expectedResponses) {
         SuccessResponse<List<FindSelfOptionResponse>> successResponse = response.body().as(new TypeRef<>() {
         });
         softAssertions.assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());

--- a/server/src/test/resources/application.yml
+++ b/server/src/test/resources/application.yml
@@ -1,4 +1,12 @@
 spring:
+  profiles:
+    active:
+      - test
+---
+spring:
+  config:
+    activate:
+      on-profile: test
   datasource:
     url: jdbc:h2:mem:test
     driverClassName: org.h2.Driver
@@ -7,9 +15,8 @@ spring:
   sql:
     init:
       mode: always
-  redis:
-    host: localhost
-    port: 6379
+  cache:
+    type: none
   origin: http://localhost:8080
 logging:
   level:

--- a/server/src/test/resources/schema.sql
+++ b/server/src/test/resources/schema.sql
@@ -1,0 +1,192 @@
+CREATE TABLE IF NOT EXISTS `dictionary`
+(
+    `id`          bigint        NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    `word`        varchar(50)   NOT NULL,
+    `description` text          NOT NULL,
+    `img_url`     varchar(2083) NULL
+);
+
+CREATE TABLE IF NOT EXISTS `car`
+(
+    `id`   bigint       NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    `name` varchar(100) NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS `trim`
+(
+    `id`                 bigint        NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    `name`               varchar(50)   NOT NULL,
+    `img_url`            varchar(2083) NOT NULL,
+    `background_img_url` varchar(2083) NOT NULL,
+    `hashtag`            varchar(50)   NOT NULL,
+    `price`              int           NOT NULL,
+    `description`        varchar(50)   NULL,
+    `car_id`             bigint        NOT NULL,
+    FOREIGN KEY (`car_id`) REFERENCES `car` (`id`)
+);
+
+CREATE TABLE IF NOT EXISTS `category`
+(
+    `id`   bigint       NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    `name` varchar(100) NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS `options`
+(
+    `id`                   bigint              NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    `name`                 varchar(100) UNIQUE NOT NULL,
+    `price`                int                 NOT NULL,
+    `feedback_title`       varchar(255)        NULL,
+    `feedback_description` varchar(255)        NULL,
+    `category_id`          bigint              NOT NULL,
+    FOREIGN KEY (`category_id`) REFERENCES `category` (`id`)
+);
+
+CREATE TABLE IF NOT EXISTS `sell`
+(
+    `id`                bigint    NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    `trim_id`           bigint    NOT NULL,
+    `engine_id`         bigint    NOT NULL,
+    `body_type_id`      bigint    NOT NULL,
+    `driving_system_id` bigint    NOT NULL,
+    `exterior_color_id` bigint    NOT NULL,
+    `interior_color_id` bigint    NOT NULL,
+    `wheel_id`          bigint    NOT NULL,
+    `age`               tinyint   NOT NULL,
+    `gender`            tinyint   NOT NULL,
+    `create_date`       timestamp NOT NULL,
+    FOREIGN KEY (`trim_id`) REFERENCES `trim` (`id`),
+    FOREIGN KEY (`engine_id`) REFERENCES `options` (`id`),
+    FOREIGN KEY (`body_type_id`) REFERENCES `options` (`id`),
+    FOREIGN KEY (`driving_system_id`) REFERENCES `options` (`id`),
+    FOREIGN KEY (`exterior_color_id`) REFERENCES `options` (`id`),
+    FOREIGN KEY (`interior_color_id`) REFERENCES `options` (`id`),
+    FOREIGN KEY (`wheel_id`) REFERENCES `options` (`id`)
+);
+
+CREATE TABLE IF NOT EXISTS `sell_selective_options`
+(
+    `id`         bigint NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    `sell_id`    bigint NOT NULL,
+    `options_id` bigint NOT NULL,
+    FOREIGN KEY (`sell_id`) REFERENCES `sell` (`id`),
+    FOREIGN KEY (`options_id`) REFERENCES `options` (`id`)
+);
+
+CREATE TABLE IF NOT EXISTS `keyword`
+(
+    `id`   bigint       NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    `name` varchar(100) NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS `options_keyword`
+(
+    `id`         bigint NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    `options_id` bigint NOT NULL,
+    `keyword_id` bigint NOT NULL,
+    FOREIGN KEY (`options_id`) REFERENCES `options` (`id`),
+    FOREIGN KEY (`keyword_id`) REFERENCES `keyword` (`id`)
+);
+
+CREATE TABLE IF NOT EXISTS `estimate`
+(
+    `id`                bigint    NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    `trim_id`           bigint    NOT NULL,
+    `engine_id`         bigint    NOT NULL,
+    `body_type_id`      bigint    NOT NULL,
+    `driving_system_id` bigint    NOT NULL,
+    `exterior_color_id` bigint    NOT NULL,
+    `interior_color_id` bigint    NOT NULL,
+    `wheel_id`          bigint    NOT NULL,
+    `keyword1_id`       bigint    NOT NULL,
+    `keyword2_id`       bigint    NOT NULL,
+    `keyword3_id`       bigint    NOT NULL,
+    `age_range`         tinyint   NOT NULL,
+    `gender`            tinyint   NOT NULL,
+    `create_date`       timestamp NOT NULL,
+    FOREIGN KEY (`trim_id`) REFERENCES `trim` (`id`),
+    FOREIGN KEY (`engine_id`) REFERENCES `options` (`id`),
+    FOREIGN KEY (`body_type_id`) REFERENCES `options` (`id`),
+    FOREIGN KEY (`driving_system_id`) REFERENCES `options` (`id`),
+    FOREIGN KEY (`exterior_color_id`) REFERENCES `options` (`id`),
+    FOREIGN KEY (`interior_color_id`) REFERENCES `options` (`id`),
+    FOREIGN KEY (`wheel_id`) REFERENCES `options` (`id`),
+    FOREIGN KEY (`keyword1_id`) REFERENCES `keyword` (`id`),
+    FOREIGN KEY (`keyword2_id`) REFERENCES `keyword` (`id`),
+    FOREIGN KEY (`keyword3_id`) REFERENCES `keyword` (`id`)
+);
+
+CREATE TABLE IF NOT EXISTS `estimate_selective_options`
+(
+    `id`          bigint NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    `estimate_id` bigint NOT NULL,
+    `options_id`  bigint NOT NULL,
+    FOREIGN KEY (`estimate_id`) REFERENCES `estimate` (`id`),
+    FOREIGN KEY (`options_id`) REFERENCES `options` (`id`)
+);
+
+CREATE TABLE IF NOT EXISTS `options_image`
+(
+    `id`         bigint        NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    `img_url`    varchar(2083) NOT NULL,
+    `img_type`   tinyint       NOT NULL,
+    `options_id` bigint        NOT NULL,
+    FOREIGN KEY (`options_id`) REFERENCES `options` (`id`)
+);
+
+CREATE TABLE IF NOT EXISTS `options_detail`
+(
+    `id`          bigint        NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    `name`        varchar(100)  NULL,
+    `description` text          NOT NULL,
+    `img_url`     varchar(2083) NULL,
+    `options_id`  bigint        NOT NULL,
+    FOREIGN KEY (`options_id`) REFERENCES `options` (`id`)
+);
+
+CREATE TABLE IF NOT EXISTS `spec`
+(
+    `id`                bigint       NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    `name`              varchar(50)  NOT NULL,
+    `description`       varchar(100) NOT NULL,
+    `options_detail_id` bigint       NOT NULL,
+    FOREIGN KEY (`options_detail_id`) REFERENCES `options` (`id`)
+);
+
+CREATE TABLE IF NOT EXISTS `trim_options`
+(
+    `id`         bigint  NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    `type`       tinyint NOT NULL,
+    `trim_id`    bigint  NOT NULL,
+    `options_id` bigint  NOT NULL,
+    FOREIGN KEY (`trim_id`) REFERENCES `trim` (`id`),
+    FOREIGN KEY (`options_id`) REFERENCES `options` (`id`)
+);
+
+CREATE TABLE IF NOT EXISTS `options_relation`
+(
+    `id`        bigint NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    `parent_id` bigint NOT NULL,
+    `child_id`  bigint NOT NULL,
+    FOREIGN KEY (`parent_id`) REFERENCES `options` (`id`),
+    FOREIGN KEY (`child_id`) REFERENCES `options` (`id`)
+);
+
+
+create index idx_body_type_trim
+    on sell (body_type_id, trim_id);
+
+create index idx_driving_system_trim
+    on sell (driving_system_id, trim_id);
+
+create index idx_engine_trim
+    on sell (engine_id, trim_id);
+
+create index idx_exterior_color_trim
+    on sell (exterior_color_id, trim_id);
+
+create index idx_interior_color_trim
+    on sell (interior_color_id, trim_id);
+
+create index idx_wheel_trim
+    on sell (wheel_id, trim_id);


### PR DESCRIPTION
## 📕 요약
Self mode API 성능 개선
close #203 

## 📗 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] 판매량 쿼리에 인덱스 및 캐시 적용
- [x] 서버 db에 sell의 각 옵션 별로 trim_id와 함께 복합 인덱스 적용

### 4.74초 --(인덱스 적용)-> 0.51초 --(캐시 적용)-> 0.06초
<img width="995" alt="스크린샷 2023-08-21 오후 10 49 07" src="https://github.com/softeerbootcamp-2nd/H8-YoungCha/assets/63232876/083d011e-64f8-46b8-93f5-4d1bba006f74">

<img width="990" alt="스크린샷 2023-08-21 오후 10 50 20" src="https://github.com/softeerbootcamp-2nd/H8-YoungCha/assets/63232876/555675b3-c414-4f50-9883-284c18df5cea">

<img width="991" alt="스크린샷 2023-08-21 오후 10 51 31" src="https://github.com/softeerbootcamp-2nd/H8-YoungCha/assets/63232876/dcd8010c-e361-4219-8353-7f54c1a10c8e">


## 📘 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- Map<Long,Long>에는 mapCacheManager를 적용해 줘야한다.
  - GenericJackson2JsonRedisSerializer는 map의 key를 string으로 저장하기 때문에 Long으로 타입 변환이 안되서 에러가 발생한다.
- 기본은 defaultCacheManger가 적용된다.

