### PR TITLE
[BE] Nginx https 적용

### DIFF
--- a/server/script/profile.sh
+++ b/server/script/profile.sh
@@ -2,14 +2,14 @@
 
 # nginx와 연결되지 않은 profile 찾기(활성화시킬 profile)
 function find_idle_profile() {
-  RESPONSE_CODE=$(curl -s -o /dev/null -w "%{http_code}" http://localhost/profiles)
+  RESPONSE_CODE=$(curl -s -o /dev/null -w "%{http_code}" https://api.youngcha.team/profiles)
 
   if [ "$RESPONSE_CODE" -ge 400 ]
   then
     # nginx와 연결된 컨테이너가 없으면 spring2가 연결되어 있다고 설정
     CURRENT_PROFILE=spring2
   else
-    CURRENT_PROFILE=$(curl -s http://localhost/profiles)
+    CURRENT_PROFILE=$(curl -s https://api.youngcha.team/profiles)
   fi
 
   # 구동할 profile 설정


### PR DESCRIPTION
## 📕 요약

관련이슈 #232 

## 📗 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] 배포에 사용되는 api 수정
- [x] nginx 파일 설정
```shell
server {
        listen 80;
        server_name api.youngcha.team, localhost;

        location /.well-known/acme-challenge/ {
                root /var/lib/letsencrypt/;
        }

        location / {
                return 301 https://$host$request_uri;
        }
}


server {
        listen 443 ssl;
        server_name api.youngcha.team, localhost;

        include /etc/nginx/conf.d/service-url.inc;

        ssl_certificate /etc/letsencrypt/live/api.youngcha.team/fullchain.pem;
        ssl_certificate_key /etc/letsencrypt/live/api.youngcha.team/privkey.pem;

        location / {
                resolver                        127.0.0.11;
                proxy_pass                   $service_url;
                proxy_set_header        X-Real-IP $remote_addr;
                proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
                proxy_set_header        Host $http_host;
                proxy_http_version      1.1;
        }
}

```
