### PR TITLE
[BE] 가이드 모드 선택 옵션 조회 기능 수정

### DIFF
--- a/server/src/main/java/team/youngcha/domain/option/service/OptionService.java
+++ b/server/src/main/java/team/youngcha/domain/option/service/OptionService.java
@@ -252,13 +252,14 @@ public class OptionService {
         boolean containDrivingPerformance = userSelectedKeywordIds.contains(keywords.get(KeywordName.DRIVING_PERFORMANCE.getName()));
         boolean containSafety = userSelectedKeywordIds.contains(keywords.get(KeywordName.SAFETY.getName()));
 
-        if (!containDesign && !containDrivingPerformance && !containSafety) {
-            return "20인치 알로이 휠";
+        if (containDesign) {
+            if (containDrivingPerformance || containSafety) {
+                return "알콘(alcon) 단조 브레이크 & 20인치 휠 패키지";
+            }
+            return getRecommendedWheelNameBySimilarity(similarityUsersRatio);
         }
-        if (containDrivingPerformance || containSafety) {
-            return "알콘(alcon) 단조 브레이크 & 20인치 휠 패키지";
-        }
-        return getRecommendedWheelNameBySimilarity(similarityUsersRatio);
+
+        return "20인치 알로이 휠";
     }
 
     private String getRecommendedWheelNameBySimilarity(Map<Long, Integer> similarityUsersRatio) {


### PR DESCRIPTION
## 📕 요약
close #243
## 📗 작업 내용
- 가이드 모드 휠 추천 로직 오류 수정
  - 사용자가 디자인 키워드를 고르지 않아도 기본 휠 이외의 옵션이 추천되는 오류 수정
- 가이드 모드 선택 옵션 조회 기능 변경
  - 옵션 조회 목록 수정
    - before: 사용자 선택 키워드를 포함하는 옵션만 목록에 포함
    - after: 모든 선택 옵션을 목록에 포함
  - 선택 옵션 추천 방식 변경
    - before: 선택 옵션의 경우 추천하지 않음
    - after: 사용자 키워드를 포함한 모든 옵션을 추천
## 📘 PR 특이 사항
- 테이블에 인덱스를 적용하여 응답 시간 28초에서 12초로 감소 
<img width="1297" alt="image" src="https://github.com/softeerbootcamp-2nd/H8-YoungCha/assets/107951175/2e44230e-0f09-41c8-ab4c-fcfd9a300c5a">
