### PR TITLE
[FE] 선택 옵션 선택 페이지

### DIFF
--- a/client/src/assets/mock/mock.ts
+++ b/client/src/assets/mock/mock.ts
@@ -82,12 +82,14 @@ export const mockUserSelectedOptionData: UserSelectedOptionDataType = {
     title: '팰리세이드 Le Blanc (르블랑)',
     options: {
       trim: {
+        id: 2,
         type: '트림',
         name: 'Le Blanc',
         imgUrl: '/src/assets/mock/images/palisade.png',
         price: 1000000,
       },
       powerTrain: {
+        id: 1,
         type: '파워트레인',
         name: '디젤 2.2',
         imgUrl: '/src/assets/mock/images/palisade.png',
@@ -95,6 +97,7 @@ export const mockUserSelectedOptionData: UserSelectedOptionDataType = {
         categoryId: 1,
       },
       drivingSystem: {
+        id: 3,
         type: '구동 방식',
         name: '2WD',
         imgUrl: '/src/assets/mock/images/palisade.png',
@@ -102,6 +105,7 @@ export const mockUserSelectedOptionData: UserSelectedOptionDataType = {
         categoryId: 2,
       },
       bodyType: {
+        id: 5,
         type: '바디 타입',
         name: '7인승',
         imgUrl: '/src/assets/mock/images/palisade.png',
@@ -109,6 +113,7 @@ export const mockUserSelectedOptionData: UserSelectedOptionDataType = {
         categoryId: 3,
       },
       wheel: {
+        id: 15,
         type: '휠',
         name: '20인치',
         imgUrl: '/src/assets/mock/images/palisade.png',
@@ -122,6 +127,7 @@ export const mockUserSelectedOptionData: UserSelectedOptionDataType = {
     title: '색상',
     options: {
       exteriorColor: {
+        id: 12,
         type: '외장 색상',
         name: '크리미 화이트 펄',
         imgUrl: '/src/assets/mock/images/palisade.png',
@@ -129,6 +135,7 @@ export const mockUserSelectedOptionData: UserSelectedOptionDataType = {
         categoryId: 5,
       },
       interiorColor: {
+        id: 13,
         type: '내장 색상',
         name: '퀼팅천연 (블랙)',
         imgUrl: '/src/assets/mock/images/palisade.png',
@@ -142,6 +149,7 @@ export const mockUserSelectedOptionData: UserSelectedOptionDataType = {
     title: '옵션',
     options: [
       {
+        id: 17,
         type: '선택 옵션',
         name: '컴포트 2',
         imgUrl: '/src/assets/mock/images/palisade.png',
@@ -149,6 +157,7 @@ export const mockUserSelectedOptionData: UserSelectedOptionDataType = {
         categoryId: 7,
       },
       {
+        id: 18,
         type: '선택 옵션',
         name: '현대 스마트 센스 1',
         imgUrl: '/src/assets/mock/images/palisade.png',
@@ -156,6 +165,7 @@ export const mockUserSelectedOptionData: UserSelectedOptionDataType = {
         categoryId: 7,
       },
       {
+        id: 19,
         type: '선택 옵션',
         name: '주차 보조 시스템 2',
         imgUrl: '/src/assets/mock/images/palisade.png',

--- a/client/src/components/OptionCard/AdditionalContents/SubOptionDescription.tsx
+++ b/client/src/components/OptionCard/AdditionalContents/SubOptionDescription.tsx
@@ -1,17 +1,20 @@
+import { PropsWithChildren } from 'react';
+
 interface SubOptionDescriptionProps {
   isActive: boolean;
 }
 
-function SubOptionDescription({ isActive }: SubOptionDescriptionProps) {
-  const description =
-    '선행 차량이 갑자기 속도를 줄이거나, 앞에 정지 차량 혹은 보행자가 나타나는 등 전방 충돌 위험이 감지되면 경고를 해줍니다. 경고 후에도 충돌 위험이 높아지면 자동으로 제동을 도와줍니다.';
+function SubOptionDescription({
+  children,
+  isActive,
+}: PropsWithChildren<SubOptionDescriptionProps>) {
   return (
     <div
       className={`${
         isActive ? 'text-grey-black' : 'text-grey-003'
       } body3 mt-8px`}
     >
-      {description}
+      {children}
     </div>
   );
 }

--- a/client/src/components/OptionCard/AdditionalContents/SubOptions.tsx
+++ b/client/src/components/OptionCard/AdditionalContents/SubOptions.tsx
@@ -1,18 +1,19 @@
 import { Fragment, useState } from 'react';
+import SubOptionDescription from '@/components/OptionCard/AdditionalContents/SubOptionDescription.tsx';
+import { OptionDetailType } from '@/types/option.ts';
+interface SubOptionsProps {
+  options: OptionDetailType[];
+  isActive: boolean;
+}
 
-function SubOptions() {
-  const options = [
-    '전방 충돌 방지 보조',
-    '내비게이션 기반 스마트 크루즈 컨트롤',
-    '고속도로 주행보조 2',
-  ];
+function SubOptions({ options, isActive }: SubOptionsProps) {
   const [subSelectedIndex, setsubSelectedIndex] = useState(0);
 
   function handleOnClick(
     event: React.MouseEvent<HTMLParagraphElement>,
     index: number
   ) {
-    event.stopPropagation();
+    isActive && event.stopPropagation();
     setsubSelectedIndex(index);
   }
 
@@ -22,16 +23,19 @@ function SubOptions() {
         <Fragment key={`SubOption-${index}`}>
           <p
             className={`${
-              subSelectedIndex === index ? 'text-grey-black font-medium' : ''
-            }`}
+              isActive && subSelectedIndex === index ? 'text-grey-black' : ''
+            } ${isActive ? 'font-medium' : ''}`}
             onClick={(event) => handleOnClick(event, index)}
             role="none"
           >
-            {item}
+            {item.name}
           </p>
           {index !== options.length - 1 && <p>ㆍ</p>}
         </Fragment>
       ))}
+      <SubOptionDescription isActive={isActive}>
+        {options[subSelectedIndex].description}
+      </SubOptionDescription>
     </div>
   );
 }

--- a/client/src/components/OptionCard/Skeleton.tsx
+++ b/client/src/components/OptionCard/Skeleton.tsx
@@ -1,0 +1,31 @@
+import { GreyCheckIcon, MoreDetailsArrow } from '@/assets/icons';
+
+function Skeleton() {
+  return (
+    <button
+      className="relative border-2 rounded-6px min-w-320px w-full p-20px cursor-pointer
+      border-grey-003 bg-white max-h-fit transition-all ease-in duration-500 animate-pulse"
+    >
+      <div className="flex gap-8px">
+        <GreyCheckIcon />
+      </div>
+      <div className="body2 mt-10px mb-4px rounded-6px bg-grey-002 text-grey-002 w-100px">
+        {/*<span className="rounded-6px bg-grey-003 h-10px" />*/}
+        {'Loading'}
+      </div>
+      <div className="font-medium text-20px mb-10px bg-grey-002 text-grey-002 w-180px  rounded-6px">
+        {/*<span className="rounded-6px bg-grey-003 h-8px" />*/}
+        {'Loading'}
+      </div>
+      <div className="flex justify-between">
+        <div className="body2 text-grey-003">+ 00,000,000원</div>
+        <div className="relative flex justify-center text-center gap-2px">
+          <span className="font-medium text-grey-003 body3">자세히 보기</span>
+          <MoreDetailsArrow className="transition duration-300 transform-gpu" />
+        </div>
+      </div>
+    </button>
+  );
+}
+
+export default Skeleton;

--- a/client/src/components/OptionCard/Tags.tsx
+++ b/client/src/components/OptionCard/Tags.tsx
@@ -8,7 +8,7 @@ function Tags({ tags }: TagsProps) {
       key={`tags-${index}`}
       className="flex items-center body3 bg-tag-skyblue px-8px rounded-2px text-main-blue"
     >
-      {`${tag.name} ${tag.rate}%`}
+      {`${tag.name}  ${tag.rate}%`}
     </div>
   ));
 }

--- a/client/src/components/OptionCard/index.tsx
+++ b/client/src/components/OptionCard/index.tsx
@@ -18,9 +18,15 @@ interface OptionCardProps {
   item: AllOptionType;
   isActive?: boolean;
   onClick?: () => void;
+  multiSelect?: boolean;
 }
 
-function OptionCard({ isActive = false, item, onClick }: OptionCardProps) {
+function OptionCard({
+  isActive = false,
+  item,
+  onClick,
+  multiSelect,
+}: OptionCardProps) {
   const [isExpanded, setIsExpanded] = useState(false);
 
   const optionCardRef = useRef<HTMLButtonElement>(null);
@@ -39,7 +45,7 @@ function OptionCard({ isActive = false, item, onClick }: OptionCardProps) {
   function handleIsActive() {
     // setIsActive((prevState) => !prevState);
     onClick?.();
-    if (isActive) setIsExpanded((prevState) => !prevState);
+    if (isActive && !multiSelect) setIsExpanded((prevState) => !prevState);
   }
 
   useEffect(() => {
@@ -60,7 +66,7 @@ function OptionCard({ isActive = false, item, onClick }: OptionCardProps) {
       } transition-all ease-in duration-500`}
       onClick={handleIsActive}
     >
-      <div className="flex">
+      <div className="flex gap-8px">
         <CheckIcon {...{ isActive, isSelfMode }} />
         <Tags tags={item?.tags} />
       </div>
@@ -78,8 +84,16 @@ function OptionCard({ isActive = false, item, onClick }: OptionCardProps) {
       >
         {item.details[0]?.description && (
           <div className="flex flex-col border-t-2 border-grey-001 py-12px gap-y-12px">
-            <SummarySection details={item.details} isActive={isActive} />
-            <FunctionDetailBox details={item.details} isActive={isActive} />
+            {multiSelect ? (
+              <>
+                <SubOptions options={item?.details} isActive={isActive} />
+              </>
+            ) : (
+              <>
+                <SummarySection details={item.details} isActive={isActive} />
+                <FunctionDetailBox details={item.details} isActive={isActive} />
+              </>
+            )}
           </div>
         )}
       </div>

--- a/client/src/components/OptionCard/index.tsx
+++ b/client/src/components/OptionCard/index.tsx
@@ -5,7 +5,6 @@ import SummarySection from './AdditionalContents/SummarySection';
 import FunctionDetailBox from './AdditionalContents/FunctionDetailBox';
 import PriceSection from './PriceSection';
 import SubOptions from './AdditionalContents/SubOptions';
-import SubOptionDescription from './AdditionalContents/SubOptionDescription';
 import ImgSection from './ImgSection';
 import Tags from './Tags';
 import Rate from '@/components/OptionCard/Rate.tsx';
@@ -105,7 +104,4 @@ function OptionCard({
   );
 }
 
-export default Object.assign(OptionCard, {
-  SubOptions,
-  SubOptionDescription,
-});
+export default OptionCard;

--- a/client/src/components/RotateCarImage/index.tsx
+++ b/client/src/components/RotateCarImage/index.tsx
@@ -54,7 +54,7 @@ function RotateCarImage({ images, className }: ImageRotatorProps) {
             state.isMouseDown ? 'cursor-grabbing' : 'cursor-grab'
           } relative w-full flex justify-center ${className}`}
         >
-          <div className="relative flex justify-center items-center">
+          <div className="relative w-full flex justify-center items-center">
             {images.map((imgSrc, idx) => (
               <img
                 src={imgSrc}

--- a/client/src/components/RotateCarImage/index.tsx
+++ b/client/src/components/RotateCarImage/index.tsx
@@ -1,5 +1,6 @@
 import useRotate from '@/hooks/useRotate.ts';
 import { MouseEventHandler, useLayoutEffect, useState } from 'react';
+import Spinner from '@/components/Spinner';
 
 interface ImageRotatorProps {
   images: string[];
@@ -37,26 +38,7 @@ function RotateCarImage({ images, className }: ImageRotatorProps) {
     <>
       {isImageLoading ? (
         <div className={`flex items-center justify-center ${className}`}>
-          <svg
-            className="animate-spin -ml-1 mr-3 h-5 w-5 text-black"
-            xmlns="http://www.w3.org/2000/svg"
-            fill="none"
-            viewBox="0 0 24 24"
-          >
-            <circle
-              className="opacity-25"
-              cx="12"
-              cy="12"
-              r="10"
-              stroke="currentColor"
-              strokeWidth="4"
-            ></circle>
-            <path
-              className="opacity-75"
-              fill="currentColor"
-              d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-            ></path>
-          </svg>
+          <Spinner />
         </div>
       ) : (
         <div

--- a/client/src/components/RotateCarImage/index.tsx
+++ b/client/src/components/RotateCarImage/index.tsx
@@ -1,4 +1,4 @@
-import useRotate from '@/hooks/useRotate';
+import useRotate from '@/hooks/useRotate.ts';
 import { MouseEventHandler, useLayoutEffect, useState } from 'react';
 
 interface ImageRotatorProps {

--- a/client/src/components/Spinner/index.tsx
+++ b/client/src/components/Spinner/index.tsx
@@ -1,0 +1,26 @@
+function Spinner() {
+  return (
+    <svg
+      className="animate-spin -ml-1 mr-3 h-40px w-40px text-grey-004"
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+    >
+      <circle
+        className="opacity-25"
+        cx="12"
+        cy="12"
+        r="10"
+        stroke="currentColor"
+        strokeWidth="4"
+      ></circle>
+      <path
+        className="opacity-75"
+        fill="currentColor"
+        d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+      ></path>
+    </svg>
+  );
+}
+
+export default Spinner;

--- a/client/src/hooks/useFetch.ts
+++ b/client/src/hooks/useFetch.ts
@@ -1,5 +1,5 @@
 import { get } from '@/service';
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useDeferredValue } from 'react';
 
 interface FetchType {
   url: string;
@@ -10,17 +10,19 @@ interface FetchType {
 
 function useFetch<T>({ url, params, deps = [] }: FetchType) {
   const [loading, setLoading] = useState(true);
+  const deferredLoading = useDeferredValue(loading);
   const [data, setData] = useState<T>({} as T);
 
   useEffect(() => {
     (async () => {
+      setLoading(true);
       const data = await get<T>({ url, params });
       setData(data as T);
       setLoading(false);
     })();
   }, [url, ...deps]);
 
-  return { loading, data };
+  return { loading: deferredLoading, data };
 }
 
 export default useFetch;

--- a/client/src/pages/making/complete/CompleteOptionPage.tsx
+++ b/client/src/pages/making/complete/CompleteOptionPage.tsx
@@ -43,6 +43,7 @@ function CompleteOptionPage() {
               url: 'https://www.hyundai.com/contents/vr360/LX06/exterior/WC9/colorchip-exterior.png',
               count: 60,
             })}
+            className={`w-[600px] h-[400px]`}
           />
           <div className="flex">
             {CAR_COLOR.map(({ text, type }) => (

--- a/client/src/pages/making/complete/CompleteOptionPage.tsx
+++ b/client/src/pages/making/complete/CompleteOptionPage.tsx
@@ -6,7 +6,7 @@ import { ColorType, OptionGroupType } from '../type';
 import DetailOptionBox from '../detail-option-box/DetailOptionBox';
 import DetailSelectOptionBox from '../detail-option-box/DetailSelectOptionBox';
 import DetailBasicOptionBox from '../detail-option-box/DetailBasicOptionBox';
-import RotateCarImage from './RoateCarImage';
+import RotateCarImage from '@/components/RotateCarImage';
 import getRotateImages from '@/utils/getRotateImages';
 import Confetti from '@/components/Confetti';
 import { UserSelectedOptionDataContext } from '..';

--- a/client/src/pages/making/complete/RoateCarImage.tsx
+++ b/client/src/pages/making/complete/RoateCarImage.tsx
@@ -3,9 +3,10 @@ import { MouseEventHandler, useLayoutEffect, useState } from 'react';
 
 interface ImageRotatorProps {
   images: string[];
+  className?: string;
 }
 
-function RotateCarImage({ images }: ImageRotatorProps) {
+function RotateCarImage({ images, className }: ImageRotatorProps) {
   const { state, handleMouseDown, handleMouseMove, handleMouseUp } =
     useRotate();
   const preventEventDefault: MouseEventHandler<HTMLDivElement> = (e) =>
@@ -35,7 +36,7 @@ function RotateCarImage({ images }: ImageRotatorProps) {
   return (
     <>
       {isImageLoading ? (
-        <div className={`flex items-center justify-center`}>
+        <div className={`flex items-center justify-center ${className}`}>
           <svg
             className="animate-spin -ml-1 mr-3 h-5 w-5 text-black"
             xmlns="http://www.w3.org/2000/svg"
@@ -69,9 +70,9 @@ function RotateCarImage({ images }: ImageRotatorProps) {
           onMouseLeave={handleMouseUp}
           className={`${
             state.isMouseDown ? 'cursor-grabbing' : 'cursor-grab'
-          } relative w-full flex justify-center h-200px`}
+          } relative w-full flex justify-center ${className}`}
         >
-          <div className="relative">
+          <div className="relative flex justify-center items-center">
             {images.map((imgSrc, idx) => (
               <img
                 src={imgSrc}
@@ -80,8 +81,6 @@ function RotateCarImage({ images }: ImageRotatorProps) {
                 className={`${
                   idx === state.nextImgIdx ? 'block' : 'hidden'
                 } pointer-events-none select-none`}
-                width={400}
-                height={200}
               />
             ))}
             <div className="absolute top-0 right-0 flex items-center justify-center text-white rounded-full opacity-30 body2 bg-grey-black w-40px h-40px">

--- a/client/src/pages/making/complete/RoateCarImage.tsx
+++ b/client/src/pages/making/complete/RoateCarImage.tsx
@@ -35,8 +35,27 @@ function RotateCarImage({ images }: ImageRotatorProps) {
   return (
     <>
       {isImageLoading ? (
-        <div className="flex items-center justify-center h-200px">
-          loading...
+        <div className={`flex items-center justify-center`}>
+          <svg
+            className="animate-spin -ml-1 mr-3 h-5 w-5 text-black"
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+          >
+            <circle
+              className="opacity-25"
+              cx="12"
+              cy="12"
+              r="10"
+              stroke="currentColor"
+              strokeWidth="4"
+            ></circle>
+            <path
+              className="opacity-75"
+              fill="currentColor"
+              d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+            ></path>
+          </svg>
         </div>
       ) : (
         <div

--- a/client/src/pages/making/constant.ts
+++ b/client/src/pages/making/constant.ts
@@ -25,12 +25,14 @@ export const INITIAL_USER_SELECTED_DATA: UserSelectedOptionDataType = {
     title: '팰리세이드 Le Blanc (르블랑)',
     options: {
       trim: {
+        id: 2,
         type: '트림',
         name: 'Le Blanc',
         imgUrl: '/src/assets/mock/images/palisade.png',
         price: 43_460_000,
       },
       powerTrain: {
+        id: 1,
         type: '파워트레인',
         name: '디젤 2.2',
         imgUrl: '/src/assets/mock/images/palisade.png',
@@ -38,6 +40,7 @@ export const INITIAL_USER_SELECTED_DATA: UserSelectedOptionDataType = {
         categoryId: 1,
       },
       drivingSystem: {
+        id: 3,
         type: '구동 방식',
         name: '2WD',
         imgUrl: '/src/assets/mock/images/palisade.png',
@@ -45,6 +48,7 @@ export const INITIAL_USER_SELECTED_DATA: UserSelectedOptionDataType = {
         categoryId: 2,
       },
       bodyType: {
+        id: 5,
         type: '바디 타입',
         name: '7인승',
         imgUrl: '/src/assets/mock/images/palisade.png',
@@ -52,6 +56,7 @@ export const INITIAL_USER_SELECTED_DATA: UserSelectedOptionDataType = {
         categoryId: 3,
       },
       wheel: {
+        id: 15,
         type: '휠',
         name: '20인치',
         imgUrl: '/src/assets/mock/images/palisade.png',
@@ -65,6 +70,7 @@ export const INITIAL_USER_SELECTED_DATA: UserSelectedOptionDataType = {
     title: '색상',
     options: {
       exteriorColor: {
+        id: 12,
         type: '외장 색상',
         name: '크리미 화이트 펄',
         imgUrl: '/src/assets/mock/images/palisade.png',
@@ -72,6 +78,7 @@ export const INITIAL_USER_SELECTED_DATA: UserSelectedOptionDataType = {
         categoryId: 4,
       },
       interiorColor: {
+        id: 13,
         type: '내장 색상',
         name: '퀼팅천연 (블랙)',
         imgUrl: '/src/assets/mock/images/palisade.png',

--- a/client/src/pages/making/detail-option-box/DetailOptionHeader.tsx
+++ b/client/src/pages/making/detail-option-box/DetailOptionHeader.tsx
@@ -2,7 +2,7 @@ import { formatPrice } from '@/utils';
 import { OptionType } from '../type';
 
 interface DetailOptionHeaderProps {
-  option: Omit<OptionType, 'name' | 'imgUrl'>;
+  option: Omit<OptionType, 'name' | 'imgUrl' | 'id'>;
 }
 
 function DetailOptionHeader({ option }: DetailOptionHeaderProps) {

--- a/client/src/pages/making/detail-option-box/DetailOptionList.tsx
+++ b/client/src/pages/making/detail-option-box/DetailOptionList.tsx
@@ -5,7 +5,7 @@ import { Link, useParams } from 'react-router-dom';
 import getStep from '@/utils/getStep';
 
 interface DetailOptionListProps {
-  option: OptionType;
+  option: Omit<OptionType, 'id'>;
 }
 
 function DetailOptionList({ option }: DetailOptionListProps) {

--- a/client/src/pages/making/index.tsx
+++ b/client/src/pages/making/index.tsx
@@ -1,11 +1,12 @@
+import { createContext } from 'react';
 import { useLocation, useParams } from 'react-router-dom';
 import SelectOptionPage from './select/SelectOptionPage';
+import SelectMultiOptionPage from '@/pages/making/select/SelectMultiOptionPage.tsx';
 import CompleteOptionPage from './complete/CompleteOptionPage';
 import CompleteOptionPageWithLoading from './complete/CompleteOptionPageWithLoading';
+import useSelectOption from '@/hooks/useSelectOption.ts';
 import { INITIAL_USER_SELECTED_DATA, LAST_STEP } from './constant';
 import { OptionType, UserSelectedOptionDataType } from './type';
-import { createContext } from 'react';
-import useSelectOption from '@/hooks/useSelectOption.ts';
 
 export interface UserSelectedOptionDataContextType {
   userSelectedOptionData: UserSelectedOptionDataType;
@@ -22,6 +23,23 @@ function MakingPage() {
   const { step } = useParams() as { step: string };
   const { state } = useLocation();
 
+  if (Number(step) === LAST_STEP) {
+    return state?.isGuide ? (
+      <CompleteOptionPage />
+    ) : (
+      <CompleteOptionPageWithLoading />
+    );
+  }
+
+  if (Number(step) === LAST_STEP - 1) {
+    return <SelectMultiOptionPage />;
+  }
+
+  return <SelectOptionPage />;
+}
+
+export { default as MakingPageLayout } from './layout.tsx';
+export default function MakingPageWithProvider() {
   const { userSelectedOptionData, saveOptionData } = useSelectOption();
 
   return (
@@ -31,16 +49,7 @@ function MakingPage() {
         saveOptionData,
       }}
     >
-      {Number(step) !== LAST_STEP ? (
-        <SelectOptionPage />
-      ) : state?.isGuide ? (
-        <CompleteOptionPage />
-      ) : (
-        <CompleteOptionPageWithLoading />
-      )}
+      <MakingPage />
     </UserSelectedOptionDataContext.Provider>
   );
 }
-
-export { default as MakingPageLayout } from './layout.tsx';
-export default MakingPage;

--- a/client/src/pages/making/index.tsx
+++ b/client/src/pages/making/index.tsx
@@ -7,6 +7,7 @@ import CompleteOptionPageWithLoading from './complete/CompleteOptionPageWithLoad
 import useSelectOption from '@/hooks/useSelectOption.ts';
 import { INITIAL_USER_SELECTED_DATA, LAST_STEP } from './constant';
 import { OptionType, UserSelectedOptionDataType } from './type';
+import { PathParamsType } from '@/types/router.ts';
 
 export interface UserSelectedOptionDataContextType {
   userSelectedOptionData: UserSelectedOptionDataType;
@@ -20,7 +21,7 @@ export const UserSelectedOptionDataContext =
   });
 
 function MakingPage() {
-  const { step } = useParams() as { step: string };
+  const { step } = useParams() as PathParamsType;
   const { state } = useLocation();
 
   if (Number(step) === LAST_STEP) {

--- a/client/src/pages/making/index.tsx
+++ b/client/src/pages/making/index.tsx
@@ -1,7 +1,6 @@
 import { createContext } from 'react';
 import { useLocation, useParams } from 'react-router-dom';
-import SelectOptionPage from './select/SelectOptionPage';
-import SelectMultiOptionPage from '@/pages/making/select/SelectMultiOptionPage.tsx';
+import { SelectOptionPage, SelectMultiOptionPage } from './select';
 import CompleteOptionPage from './complete/CompleteOptionPage';
 import CompleteOptionPageWithLoading from './complete/CompleteOptionPageWithLoading';
 import useSelectOption from '@/hooks/useSelectOption.ts';
@@ -40,6 +39,7 @@ function MakingPage() {
 }
 
 export { default as MakingPageLayout } from './layout.tsx';
+
 export default function MakingPageWithProvider() {
   const { userSelectedOptionData, saveOptionData } = useSelectOption();
 

--- a/client/src/pages/making/index.tsx
+++ b/client/src/pages/making/index.tsx
@@ -1,4 +1,4 @@
-import { createContext } from 'react';
+import { createContext, useContext } from 'react';
 import { useLocation, useParams } from 'react-router-dom';
 import { SelectOptionPage, SelectMultiOptionPage } from './select';
 import CompleteOptionPage from './complete/CompleteOptionPage';
@@ -7,6 +7,12 @@ import useSelectOption from '@/hooks/useSelectOption.ts';
 import { INITIAL_USER_SELECTED_DATA, LAST_STEP } from './constant';
 import { OptionType, UserSelectedOptionDataType } from './type';
 import { PathParamsType } from '@/types/router.ts';
+import useFetch from '@/hooks/useFetch.ts';
+import { AllOptionType } from '@/types/option.ts';
+import {
+  INTERIOR_COLOR_STEP,
+  PROGRESS_LIST,
+} from '@/pages/making/select/constant.ts';
 
 export interface UserSelectedOptionDataContextType {
   userSelectedOptionData: UserSelectedOptionDataType;
@@ -20,7 +26,7 @@ export const UserSelectedOptionDataContext =
   });
 
 function MakingPage() {
-  const { step } = useParams() as PathParamsType;
+  const { step, mode } = useParams() as PathParamsType;
   const { state } = useLocation();
 
   if (Number(step) === LAST_STEP) {
@@ -31,14 +37,37 @@ function MakingPage() {
     );
   }
 
-  if (Number(step) === LAST_STEP - 1) {
-    return <SelectMultiOptionPage />;
-  }
+  const { userSelectedOptionData } = useContext(UserSelectedOptionDataContext);
+  const url = `/car-make/2/${mode}/${PROGRESS_LIST[Number(step) - 1].path}`;
 
-  return <SelectOptionPage />;
+  const { data, loading: isLoading } = useFetch<AllOptionType[]>({
+    url,
+    params:
+      mode === 'guide'
+        ? ({
+            keyword1Id: '1',
+            keyword2Id: '2',
+            keyword3Id: '3',
+            age: '2',
+            gender: '0',
+            exteriorColorId:
+              Number(step) === INTERIOR_COLOR_STEP
+                ? userSelectedOptionData.colors.options.exteriorColor.id.toString()
+                : '0',
+          } as Record<string, string>)
+        : Number(step) === INTERIOR_COLOR_STEP
+        ? ({
+            exteriorColorId:
+              userSelectedOptionData.colors.options.exteriorColor.id.toString(),
+          } as Record<string, string>)
+        : undefined,
+  });
+
+  if (Number(step) === LAST_STEP - 1)
+    return <SelectMultiOptionPage {...{ data, isLoading }} />;
+
+  return <SelectOptionPage {...{ data, isLoading }} />;
 }
-
-export { default as MakingPageLayout } from './layout.tsx';
 
 export default function MakingPageWithProvider() {
   const { userSelectedOptionData, saveOptionData } = useSelectOption();
@@ -54,3 +83,5 @@ export default function MakingPageWithProvider() {
     </UserSelectedOptionDataContext.Provider>
   );
 }
+
+export { default as MakingPageLayout } from './layout.tsx';

--- a/client/src/pages/making/select/SelectMultiOptionPage.tsx
+++ b/client/src/pages/making/select/SelectMultiOptionPage.tsx
@@ -1,55 +1,27 @@
-import { useContext, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
-import { UserSelectedOptionDataContext } from '@/pages/making';
 import OptionCard from '@/components/OptionCard';
 import {
   SelectOptionMessage,
   SelectOptionListContainer,
   SelectOptionFooter,
 } from './';
-import useFetch from '@/hooks/useFetch.ts';
 import { PathParamsType } from '@/types/router';
 import { AllOptionType } from '@/types/option';
-import { INTERIOR_COLOR_STEP, PROGRESS_LIST } from './constant';
+import { SelectOptionPageProps } from '@/pages/making/select/type.ts';
 
 const CATEGORY = ['시스템', '온도관리', '외부장치', '내부장치'];
 
-function SelectMultiOptionPage() {
+function SelectMultiOptionPage({ data, isLoading }: SelectOptionPageProps) {
   const { step, mode, id } = useParams() as PathParamsType;
-  const url = `/car-make/2/${mode}/${PROGRESS_LIST[Number(step) - 1].path}`;
 
-  const { userSelectedOptionData } = useContext(UserSelectedOptionDataContext);
-
-  const { data, loading } = useFetch<AllOptionType[]>({
-    url,
-    params:
-      mode === 'guide'
-        ? ({
-            keyword1Id: '1',
-            keyword2Id: '2',
-            keyword3Id: '3',
-            age: '2',
-            gender: '0',
-            exteriorColorId:
-              Number(step) === INTERIOR_COLOR_STEP
-                ? userSelectedOptionData.colors.options.exteriorColor.id.toString()
-                : '0',
-          } as Record<string, string>)
-        : Number(step) === INTERIOR_COLOR_STEP
-        ? ({
-            exteriorColorId:
-              userSelectedOptionData.colors.options.exteriorColor.id.toString(),
-          } as Record<string, string>)
-        : undefined,
-  }) as { data: AllOptionType[]; loading: boolean };
-
-  // 선택 아이템 인덳스
   const [selectedItem, setSelectedItem] = useState<number>(0);
   const [selectedItems, setSelectedItems] = useState<number[]>([]);
+
+  const [category, setCategory] = useState('시스템');
   const [categorizedData, setCategorizedData] = useState(
     {} as { [key: string]: AllOptionType[] }
   );
-  const [category, setCategory] = useState('시스템');
 
   function onNext() {
     // data: AllOptionType[]
@@ -73,7 +45,7 @@ function SelectMultiOptionPage() {
   }, [data]);
 
   return (
-    !loading && (
+    !isLoading && (
       <main className="relative flex-grow">
         <div className="absolute top-0 bottom-0 grid w-full grid-cols-2 lg:grid-cols-12">
           {/* 이미지 영역 */}

--- a/client/src/pages/making/select/SelectMultiOptionPage.tsx
+++ b/client/src/pages/making/select/SelectMultiOptionPage.tsx
@@ -9,6 +9,8 @@ import {
 import { PathParamsType } from '@/types/router';
 import { AllOptionType } from '@/types/option';
 import { SelectOptionPageProps } from '@/pages/making/select/type.ts';
+import Spinner from '@/components/Spinner';
+import Skeleton from '@/components/OptionCard/Skeleton.tsx';
 
 const CATEGORY = ['시스템', '온도관리', '외부장치', '내부장치'];
 
@@ -45,31 +47,52 @@ function SelectMultiOptionPage({ data, isLoading }: SelectOptionPageProps) {
   }, [data]);
 
   return (
-    !isLoading && (
-      <main className="relative flex-grow">
-        <div className="absolute top-0 bottom-0 grid w-full grid-cols-2 lg:grid-cols-12">
-          {/* 이미지 영역 */}
-          <div className="lg:col-span-7 relative">
-            <img
-              src={
-                data?.filter((item) => item.id === selectedItem)[0]?.images[0]
-                  .imgUrl ?? data?.[0].images[0].imgUrl
-              }
-              className="object-cover w-full h-full"
-              alt="palisade"
-            />
-            <div className="absolute bottom-0 left-0 right-0 flex justify-center items-center h-80px drop-shadow-lg">
-              <span className="body1 text-white">
-                {data?.filter((item) => item.id === selectedItem)[0]?.name ??
-                  data?.[0].name}
-              </span>
-            </div>
-          </div>
-          {/* 옵션 선택 영역 */}
-          <div className="flex flex-col max-w-lg lg:col-span-5">
-            <SelectOptionMessage step={Number(step)} />
-            <div className="flex justify-between px-32px pb-16px gap-12px">
-              {Object.keys(categorizedData)?.map((key) => (
+    <main className="relative flex-grow">
+      <div className="absolute top-0 bottom-0 grid w-full grid-cols-2 lg:grid-cols-12">
+        {/* 이미지 영역 */}
+        <div className="lg:col-span-7 relative flex flex-col justify-center items-center bg-grey-001">
+          {isLoading ? (
+            <Spinner />
+          ) : (
+            <>
+              <img
+                src={
+                  data?.filter((item) => item.id === selectedItem)[0]?.images[0]
+                    .imgUrl ?? data?.[0].images[0].imgUrl
+                }
+                className="object-cover w-full h-full"
+                alt="palisade"
+              />
+              <div className="absolute bottom-0 left-0 right-0 flex justify-center items-center h-80px drop-shadow-lg">
+                <span className="body1 text-white">
+                  {data?.filter((item) => item.id === selectedItem)[0]?.name ??
+                    data?.[0].name}
+                </span>
+              </div>
+            </>
+          )}
+        </div>
+        {/* 옵션 선택 영역 */}
+        <div className="flex flex-col max-w-lg lg:col-span-5">
+          <SelectOptionMessage step={Number(step)} />
+          <div className="flex justify-between px-32px pb-16px gap-12px">
+            {isLoading ? (
+              <>
+                <div className="flex-1 px-8px py-6px rounded-6px body3 bg-grey-002 text-grey-002">
+                  {'Loading'}
+                </div>
+                <div className="flex-1 px-8px py-6px rounded-6px body3 bg-grey-002 text-grey-002">
+                  {'Loading'}
+                </div>
+                <div className="flex-1 px-8px py-6px rounded-6px body3 bg-grey-002 text-grey-002">
+                  {'Loading'}
+                </div>
+                <div className="flex-1 px-8px py-6px rounded-6px body3 bg-grey-002 text-grey-002">
+                  {'Loading'}
+                </div>
+              </>
+            ) : (
+              Object.keys(categorizedData)?.map((key) => (
                 <button
                   className={`flex-1 px-8px py-6px rounded-6px body3 ${
                     key === category
@@ -81,10 +104,18 @@ function SelectMultiOptionPage({ data, isLoading }: SelectOptionPageProps) {
                 >
                   {key}
                 </button>
-              ))}
-            </div>
-            <SelectOptionListContainer>
-              {categorizedData[category]?.map((item: AllOptionType) => (
+              ))
+            )}
+          </div>
+          <SelectOptionListContainer>
+            {isLoading ? (
+              <>
+                <Skeleton />
+                <Skeleton />
+                <Skeleton />
+              </>
+            ) : (
+              categorizedData[category]?.map((item: AllOptionType) => (
                 <OptionCard
                   key={item.name}
                   isActive={selectedItems.indexOf(item.id) >= 0}
@@ -101,15 +132,13 @@ function SelectMultiOptionPage({ data, isLoading }: SelectOptionPageProps) {
                   item={item}
                   multiSelect
                 />
-              ))}
-            </SelectOptionListContainer>
-            <SelectOptionFooter
-              {...{ mode, id, step, onNext: () => onNext() }}
-            />
-          </div>
+              ))
+            )}
+          </SelectOptionListContainer>
+          <SelectOptionFooter {...{ mode, id, step, onNext: () => onNext() }} />
         </div>
-      </main>
-    )
+      </div>
+    </main>
   );
 }
 

--- a/client/src/pages/making/select/SelectMultiOptionPage.tsx
+++ b/client/src/pages/making/select/SelectMultiOptionPage.tsx
@@ -1,14 +1,16 @@
 import { useContext, useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
-import OptionCard from '@/components/OptionCard';
-import SelectOptionMessage from './SelectOptionMessage';
-import SelectOptionListContainer from './SelectOptionListContainer';
-import SelectOptionFooter from './SelectOptionFooter';
-import useFetch from '@/hooks/useFetch.ts';
 import { UserSelectedOptionDataContext } from '@/pages/making';
-import { INTERIOR_COLOR_STEP, PROGRESS_LIST } from './constant';
+import OptionCard from '@/components/OptionCard';
+import {
+  SelectOptionMessage,
+  SelectOptionListContainer,
+  SelectOptionFooter,
+} from './';
+import useFetch from '@/hooks/useFetch.ts';
 import { PathParamsType } from '@/types/router';
 import { AllOptionType } from '@/types/option';
+import { INTERIOR_COLOR_STEP, PROGRESS_LIST } from './constant';
 
 const CATEGORY = ['시스템', '온도관리', '외부장치', '내부장치'];
 

--- a/client/src/pages/making/select/SelectMultiOptionPage.tsx
+++ b/client/src/pages/making/select/SelectMultiOptionPage.tsx
@@ -56,20 +56,18 @@ function SelectMultiOptionPage() {
   }
 
   useEffect(() => {
-    setCategorizedData(
-      Array.isArray(data)
-        ? data?.reduce(
-            (acc, cur) => {
-              const { categoryId } = cur;
-              const categoryName = CATEGORY[categoryId - 7];
-              acc[categoryName] = acc[categoryName] ?? [];
-              acc[categoryName].push(cur);
-              return acc;
-            },
-            {} as { [key: string]: AllOptionType[] }
-          )
-        : {}
+    if (!Array.isArray(data)) return;
+    const newCategorizedData = data?.reduce(
+      (acc, cur) => {
+        const { categoryId } = cur;
+        const categoryName = CATEGORY[categoryId - 7];
+        acc[categoryName] = acc[categoryName] ?? [];
+        acc[categoryName].push(cur);
+        return acc;
+      },
+      {} as { [key: string]: AllOptionType[] }
     );
+    setCategorizedData(newCategorizedData);
   }, [data]);
 
   return (

--- a/client/src/pages/making/select/SelectMultiOptionPage.tsx
+++ b/client/src/pages/making/select/SelectMultiOptionPage.tsx
@@ -1,0 +1,144 @@
+import { useContext, useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import OptionCard from '@/components/OptionCard';
+import SelectOptionMessage from './SelectOptionMessage';
+import SelectOptionListContainer from './SelectOptionListContainer';
+import SelectOptionFooter from './SelectOptionFooter';
+import useFetch from '@/hooks/useFetch.ts';
+import { UserSelectedOptionDataContext } from '@/pages/making';
+import { INTERIOR_COLOR_STEP, PROGRESS_LIST } from './constant';
+import { PathParamsType } from '@/types/router';
+import { AllOptionType } from '@/types/option';
+
+const CATEGORY = ['시스템', '온도관리', '외부장치', '내부장치'];
+
+function SelectMultiOptionPage() {
+  const { step, mode, id } = useParams() as PathParamsType;
+  const url = `/car-make/2/${mode}/${PROGRESS_LIST[Number(step) - 1].path}`;
+
+  const { userSelectedOptionData } = useContext(UserSelectedOptionDataContext);
+
+  const { data, loading } = useFetch<AllOptionType[]>({
+    url,
+    params:
+      mode === 'guide'
+        ? ({
+            keyword1Id: '1',
+            keyword2Id: '2',
+            keyword3Id: '3',
+            age: '2',
+            gender: '0',
+            exteriorColorId:
+              Number(step) === INTERIOR_COLOR_STEP
+                ? userSelectedOptionData.colors.options.exteriorColor.id.toString()
+                : '0',
+          } as Record<string, string>)
+        : Number(step) === INTERIOR_COLOR_STEP
+        ? ({
+            exteriorColorId:
+              userSelectedOptionData.colors.options.exteriorColor.id.toString(),
+          } as Record<string, string>)
+        : undefined,
+  }) as { data: AllOptionType[]; loading: boolean };
+
+  // 선택 아이템 인덳스
+  const [selectedItem, setSelectedItem] = useState<number>(0);
+  const [selectedItems, setSelectedItems] = useState<number[]>([]);
+  const [categorizedData, setCategorizedData] = useState(
+    {} as { [key: string]: AllOptionType[] }
+  );
+  const [category, setCategory] = useState('시스템');
+
+  function onNext() {
+    // data: AllOptionType[]
+    // const newOption = data?.filter((item) => selectedItems.includes(item.id));
+    //   TODO: 배열 저장
+  }
+
+  useEffect(() => {
+    setCategorizedData(
+      Array.isArray(data)
+        ? data?.reduce(
+            (acc, cur) => {
+              const { categoryId } = cur;
+              const categoryName = CATEGORY[categoryId - 7];
+              acc[categoryName] = acc[categoryName] ?? [];
+              acc[categoryName].push(cur);
+              return acc;
+            },
+            {} as { [key: string]: AllOptionType[] }
+          )
+        : {}
+    );
+  }, [data]);
+
+  return (
+    !loading && (
+      <main className="relative flex-grow">
+        <div className="absolute top-0 bottom-0 grid w-full grid-cols-2 lg:grid-cols-12">
+          {/* 이미지 영역 */}
+          <div className="lg:col-span-7 relative">
+            <img
+              src={
+                data?.filter((item) => item.id === selectedItem)[0]?.images[0]
+                  .imgUrl ?? data?.[0].images[0].imgUrl
+              }
+              className="object-cover w-full h-full"
+              alt="palisade"
+            />
+            <div className="absolute bottom-0 left-0 right-0 flex justify-center items-center h-80px drop-shadow-lg">
+              <span className="body1 text-white">
+                {data?.filter((item) => item.id === selectedItem)[0]?.name ??
+                  data?.[0].name}
+              </span>
+            </div>
+          </div>
+          {/* 옵션 선택 영역 */}
+          <div className="flex flex-col max-w-lg lg:col-span-5">
+            <SelectOptionMessage step={Number(step)} />
+            <div className="flex justify-between px-32px pb-16px gap-12px">
+              {Object.keys(categorizedData)?.map((key) => (
+                <button
+                  className={`flex-1 px-8px py-6px rounded-6px body3 ${
+                    key === category
+                      ? 'bg-main-blue text-white'
+                      : 'bg-grey-002 text-grey-003'
+                  }`}
+                  key={key}
+                  onClick={() => setCategory(key)}
+                >
+                  {key}
+                </button>
+              ))}
+            </div>
+            <SelectOptionListContainer>
+              {categorizedData[category]?.map((item: AllOptionType) => (
+                <OptionCard
+                  key={item.name}
+                  isActive={selectedItems.indexOf(item.id) >= 0}
+                  onClick={() => {
+                    setSelectedItem(item.id);
+                    setSelectedItems((prevState) => {
+                      if (prevState.indexOf(item.id) >= 0) {
+                        return prevState.filter((id) => id !== item.id);
+                      } else {
+                        return [...prevState, item.id];
+                      }
+                    });
+                  }}
+                  item={item}
+                  multiSelect
+                />
+              ))}
+            </SelectOptionListContainer>
+            <SelectOptionFooter
+              {...{ mode, id, step, onNext: () => onNext() }}
+            />
+          </div>
+        </div>
+      </main>
+    )
+  );
+}
+
+export default SelectMultiOptionPage;

--- a/client/src/pages/making/select/SelectOptionFooter.tsx
+++ b/client/src/pages/making/select/SelectOptionFooter.tsx
@@ -1,53 +1,43 @@
 import { PathParamsType } from '@/types/router';
-import { useContext, useState } from 'react';
-import { UserSelectedOptionDataContext } from '..';
-import EstimationSummary from '@/components/SummaryModal';
+import { useState } from 'react';
+
 import { DownArrow } from '@/assets/icons';
 import { Link } from 'react-router-dom';
 import Button from '@/components/Button';
-import { AllOptionType } from '@/types/option';
-import { optionTypeName } from '@/constant';
+import SummaryModal from '@/components/SummaryModal';
 
 interface SelectOptionFooterProps
   extends Pick<PathParamsType, 'mode' | 'id' | 'step'> {
-  data: AllOptionType;
+  onNext: () => void;
 }
 
-function SelectOptionFooter({ mode, id, step, data }: SelectOptionFooterProps) {
+function SelectOptionFooter({
+  mode,
+  id,
+  step,
+  onNext,
+}: SelectOptionFooterProps) {
   const currentStep = Number(step);
 
-  const [isEstimationSummaryOpen, setIsEstimationSummaryOpen] = useState(false);
-  const { saveOptionData } = useContext(UserSelectedOptionDataContext);
-
-  function handleOnClick() {
-    const newOption = {
-      name: data.name,
-      price: data.price,
-      imgUrl: data.images[0].imgUrl,
-      categoryId: data.categoryId,
-      type: optionTypeName[data.categoryId],
-    };
-
-    saveOptionData({ newOption });
-  }
+  const [isSummaryModalOpen, setIsSummaryModalOpen] = useState(false);
 
   return (
     <>
-      <EstimationSummary
-        render={isEstimationSummaryOpen}
-        onClose={() => setIsEstimationSummaryOpen(false)}
+      <SummaryModal
+        render={isSummaryModalOpen}
+        onClose={() => setIsSummaryModalOpen(false)}
       />
       <div className="z-10 flex items-end justify-between w-full bg-white pt-24px pb-40px px-32px">
         <div className="flex flex-col gap-5px">
           <button
             className="flex gap-5px"
-            onClick={() => setIsEstimationSummaryOpen((value) => !value)}
+            onClick={() => setIsSummaryModalOpen((value) => !value)}
           >
             <span className="body2 text-grey-003">총 견적금액</span>
             <span className="bg-grey-001 rounded-4px">
               <DownArrow
                 className={`fill-grey-003 transition ${
-                  isEstimationSummaryOpen ? 'rotate-180' : ''
+                  isSummaryModalOpen ? 'rotate-180' : ''
                 }`}
               />
             </span>
@@ -64,7 +54,7 @@ function SelectOptionFooter({ mode, id, step, data }: SelectOptionFooterProps) {
             </Link>
           )}
           <Link to={`/model/${id}/making/${mode}/${Number(step) + 1}`}>
-            <Button size="sm" onClick={handleOnClick}>
+            <Button size="sm" onClick={onNext}>
               선택 완료
             </Button>
           </Link>

--- a/client/src/pages/making/select/SelectOptionPage.tsx
+++ b/client/src/pages/making/select/SelectOptionPage.tsx
@@ -64,7 +64,6 @@ function SelectOptionPage() {
 
   useEffect(() => {
     setSelectedItem(0);
-    console.log(data);
   }, [data]);
 
   return (

--- a/client/src/pages/making/select/SelectOptionPage.tsx
+++ b/client/src/pages/making/select/SelectOptionPage.tsx
@@ -76,14 +76,14 @@ function SelectOptionPage() {
             {Number(step) === EXTERIOR_COLOR_STEP ? (
               <RotateCarImage
                 images={getRotateImages({
-                  url: data?.[selectedItem].images[0].imgUrl ?? '',
+                  url: data?.[selectedItem]?.images[0].imgUrl ?? '',
                   count: 60,
                 })}
                 className="h-fit"
               />
             ) : (
               <img
-                src={data?.[selectedItem].images[0].imgUrl ?? ''}
+                src={data?.[selectedItem]?.images[0].imgUrl ?? ''}
                 className="w-full h-full object-cover"
                 alt="palisade"
               />

--- a/client/src/pages/making/select/SelectOptionPage.tsx
+++ b/client/src/pages/making/select/SelectOptionPage.tsx
@@ -11,7 +11,7 @@ import { AllOptionType } from '@/types/option';
 import { UserSelectedOptionDataContext } from '@/pages/making';
 import { optionTypeName } from '@/constant.ts';
 import getRotateImages from '@/utils/getRotateImages.ts';
-import RotateCarImage from '@/pages/making/complete/RoateCarImage.tsx';
+import RotateCarImage from '@/components/RotateCarImage';
 
 const EXTERIOR_COLOR_STEP = 5;
 

--- a/client/src/pages/making/select/SelectOptionPage.tsx
+++ b/client/src/pages/making/select/SelectOptionPage.tsx
@@ -1,17 +1,19 @@
 import { useContext, useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
-import OptionCard from '@/components/OptionCard';
-import { INTERIOR_COLOR_STEP, PROGRESS_LIST } from './constant';
-import useFetch from '@/hooks/useFetch.ts';
-import { PathParamsType } from '@/types/router';
-import SelectOptionMessage from './SelectOptionMessage';
-import SelectOptionListContainer from './SelectOptionListContainer';
-import SelectOptionFooter from './SelectOptionFooter';
-import { AllOptionType } from '@/types/option';
+import {
+  SelectOptionMessage,
+  SelectOptionListContainer,
+  SelectOptionFooter,
+} from './';
 import { UserSelectedOptionDataContext } from '@/pages/making';
-import { optionTypeName } from '@/constant.ts';
-import getRotateImages from '@/utils/getRotateImages.ts';
+import OptionCard from '@/components/OptionCard';
 import RotateCarImage from '@/components/RotateCarImage';
+import useFetch from '@/hooks/useFetch.ts';
+import getRotateImages from '@/utils/getRotateImages.ts';
+import { PathParamsType } from '@/types/router';
+import { AllOptionType } from '@/types/option';
+import { INTERIOR_COLOR_STEP, PROGRESS_LIST } from './constant';
+import { optionTypeName } from '@/constant.ts';
 
 const EXTERIOR_COLOR_STEP = 5;
 

--- a/client/src/pages/making/select/SelectOptionPage.tsx
+++ b/client/src/pages/making/select/SelectOptionPage.tsx
@@ -46,7 +46,7 @@ function SelectOptionPage({ data, isLoading }: SelectOptionPageProps) {
     <main className="relative flex-grow">
       <div className="absolute top-0 bottom-0 grid w-full grid-cols-2 lg:grid-cols-12">
         {/* 이미지 영역 */}
-        <div className="lg:col-span-7 flex flex-col justify-center items-center bg-grey-001">
+        <div className="lg:col-span-7 flex flex-col justify-center items-center bg-grey-001 px-16px">
           {isLoading ? (
             <Spinner />
           ) : Number(step) === EXTERIOR_COLOR_STEP ? (
@@ -55,7 +55,7 @@ function SelectOptionPage({ data, isLoading }: SelectOptionPageProps) {
                 url: data?.[selectedItem]?.images[0].imgUrl ?? '',
                 count: 60,
               })}
-              className="h-fit"
+              className="basis-1/2"
             />
           ) : (
             <>

--- a/client/src/pages/making/select/SelectOptionPage.tsx
+++ b/client/src/pages/making/select/SelectOptionPage.tsx
@@ -13,6 +13,8 @@ import { PathParamsType } from '@/types/router';
 import { AllOptionType } from '@/types/option';
 import { SelectOptionPageProps } from '@/pages/making/select/type.ts';
 import { optionTypeName } from '@/constant.ts';
+import Spinner from '@/components/Spinner';
+import Skeleton from '@/components/OptionCard/Skeleton.tsx';
 
 const EXTERIOR_COLOR_STEP = 5;
 
@@ -23,7 +25,7 @@ function SelectOptionPage({ data, isLoading }: SelectOptionPageProps) {
 
   // 선택 아이템 인덳스
   const [selectedItem, setSelectedItem] = useState(0);
-
+  const [isImageLoading, setIsImageLoading] = useState(true);
   function onNext(data: AllOptionType) {
     const newOption = {
       id: data.id,
@@ -41,32 +43,46 @@ function SelectOptionPage({ data, isLoading }: SelectOptionPageProps) {
   }, [data]);
 
   return (
-    !isLoading && (
-      <main className="relative flex-grow">
-        <div className="absolute top-0 bottom-0 grid w-full grid-cols-2 lg:grid-cols-12">
-          {/* 이미지 영역 */}
-          <div className="lg:col-span-7 flex flex-col justify-center">
-            {Number(step) === EXTERIOR_COLOR_STEP ? (
-              <RotateCarImage
-                images={getRotateImages({
-                  url: data?.[selectedItem]?.images[0].imgUrl ?? '',
-                  count: 60,
-                })}
-                className="h-fit"
-              />
-            ) : (
+    <main className="relative flex-grow">
+      <div className="absolute top-0 bottom-0 grid w-full grid-cols-2 lg:grid-cols-12">
+        {/* 이미지 영역 */}
+        <div className="lg:col-span-7 flex flex-col justify-center items-center bg-grey-001">
+          {isLoading ? (
+            <Spinner />
+          ) : Number(step) === EXTERIOR_COLOR_STEP ? (
+            <RotateCarImage
+              images={getRotateImages({
+                url: data?.[selectedItem]?.images[0].imgUrl ?? '',
+                count: 60,
+              })}
+              className="h-fit"
+            />
+          ) : (
+            <>
+              {isImageLoading && <Spinner />}
               <img
                 src={data?.[selectedItem]?.images[0].imgUrl ?? ''}
-                className="w-full h-full object-cover"
+                className={`w-full h-full object-cover ${
+                  isImageLoading && 'hidden'
+                } `}
+                onLoad={() => setIsImageLoading(false)}
                 alt="palisade"
               />
-            )}
-          </div>
-          {/* 옵션 선택 영역 */}
-          <div className="flex flex-col max-w-lg lg:col-span-5">
-            <SelectOptionMessage step={Number(step)} />
-            <SelectOptionListContainer>
-              {data
+            </>
+          )}
+        </div>
+        {/* 옵션 선택 영역 */}
+        <div className="flex flex-col max-w-lg lg:col-span-5">
+          <SelectOptionMessage step={Number(step)} />
+          <SelectOptionListContainer>
+            {isLoading ? (
+              <>
+                <Skeleton />
+                <Skeleton />
+              </>
+            ) : (
+              Array.isArray(data) &&
+              data
                 ?.sort((a, b) => b.rate - a.rate)
                 .map((item: AllOptionType, index) => (
                   <OptionCard
@@ -77,15 +93,15 @@ function SelectOptionPage({ data, isLoading }: SelectOptionPageProps) {
                     }}
                     item={item}
                   />
-                ))}
-            </SelectOptionListContainer>
-            <SelectOptionFooter
-              {...{ mode, id, step, onNext: () => onNext(data[selectedItem]) }}
-            />
-          </div>
+                ))
+            )}
+          </SelectOptionListContainer>
+          <SelectOptionFooter
+            {...{ mode, id, step, onNext: () => onNext(data[selectedItem]) }}
+          />
         </div>
-      </main>
-    )
+      </div>
+    </main>
   );
 }
 

--- a/client/src/pages/making/select/SelectOptionPage.tsx
+++ b/client/src/pages/making/select/SelectOptionPage.tsx
@@ -8,46 +8,18 @@ import {
 import { UserSelectedOptionDataContext } from '@/pages/making';
 import OptionCard from '@/components/OptionCard';
 import RotateCarImage from '@/components/RotateCarImage';
-import useFetch from '@/hooks/useFetch.ts';
 import getRotateImages from '@/utils/getRotateImages.ts';
 import { PathParamsType } from '@/types/router';
 import { AllOptionType } from '@/types/option';
-import { INTERIOR_COLOR_STEP, PROGRESS_LIST } from './constant';
+import { SelectOptionPageProps } from '@/pages/making/select/type.ts';
 import { optionTypeName } from '@/constant.ts';
 
 const EXTERIOR_COLOR_STEP = 5;
 
-function SelectOptionPage() {
+function SelectOptionPage({ data, isLoading }: SelectOptionPageProps) {
   const { step, mode, id } = useParams() as PathParamsType;
-  const url = `/car-make/2/${mode}/${PROGRESS_LIST[Number(step) - 1].path}`;
 
-  const { userSelectedOptionData, saveOptionData } = useContext(
-    UserSelectedOptionDataContext
-  );
-
-  const { data, loading } = useFetch<AllOptionType[]>({
-    url,
-    params:
-      // TODO: 가이드 모드에서 키워드 및 성별, 연령대 데이터 추가
-      mode === 'guide'
-        ? ({
-            keyword1Id: '1',
-            keyword2Id: '2',
-            keyword3Id: '3',
-            age: '2',
-            gender: '0',
-            exteriorColorId:
-              Number(step) === INTERIOR_COLOR_STEP
-                ? userSelectedOptionData.colors.options.exteriorColor.id.toString()
-                : '0',
-          } as Record<string, string>)
-        : Number(step) === INTERIOR_COLOR_STEP
-        ? ({
-            exteriorColorId:
-              userSelectedOptionData.colors.options.exteriorColor.id.toString(),
-          } as Record<string, string>)
-        : undefined,
-  });
+  const { saveOptionData } = useContext(UserSelectedOptionDataContext);
 
   // 선택 아이템 인덳스
   const [selectedItem, setSelectedItem] = useState(0);
@@ -69,7 +41,7 @@ function SelectOptionPage() {
   }, [data]);
 
   return (
-    !loading && (
+    !isLoading && (
       <main className="relative flex-grow">
         <div className="absolute top-0 bottom-0 grid w-full grid-cols-2 lg:grid-cols-12">
           {/* 이미지 영역 */}

--- a/client/src/pages/making/select/SelectOptionPage.tsx
+++ b/client/src/pages/making/select/SelectOptionPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useContext, useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import OptionCard from '@/components/OptionCard';
 import { INTERIOR_COLOR_STEP, PROGRESS_LIST } from './constant';
@@ -8,50 +8,106 @@ import SelectOptionMessage from './SelectOptionMessage';
 import SelectOptionListContainer from './SelectOptionListContainer';
 import SelectOptionFooter from './SelectOptionFooter';
 import { AllOptionType } from '@/types/option';
+import { UserSelectedOptionDataContext } from '@/pages/making';
+import { optionTypeName } from '@/constant.ts';
+import getRotateImages from '@/utils/getRotateImages.ts';
+import RotateCarImage from '@/pages/making/complete/RoateCarImage.tsx';
+
+const EXTERIOR_COLOR_STEP = 5;
 
 function SelectOptionPage() {
   const { step, mode, id } = useParams() as PathParamsType;
   const url = `/car-make/2/${mode}/${PROGRESS_LIST[Number(step) - 1].path}`;
+
+  const { userSelectedOptionData, saveOptionData } = useContext(
+    UserSelectedOptionDataContext
+  );
+
   const { data, loading } = useFetch<AllOptionType[]>({
     url,
     params:
-      Number(step) === INTERIOR_COLOR_STEP
-        ? {
-            exteriorColorId: '13',
-          }
+      // TODO: 가이드 모드에서 키워드 및 성별, 연령대 데이터 추가
+      mode === 'guide'
+        ? ({
+            keyword1Id: '1',
+            keyword2Id: '2',
+            keyword3Id: '3',
+            age: '2',
+            gender: '0',
+            exteriorColorId:
+              Number(step) === INTERIOR_COLOR_STEP
+                ? userSelectedOptionData.colors.options.exteriorColor.id.toString()
+                : '0',
+          } as Record<string, string>)
+        : Number(step) === INTERIOR_COLOR_STEP
+        ? ({
+            exteriorColorId:
+              userSelectedOptionData.colors.options.exteriorColor.id.toString(),
+          } as Record<string, string>)
         : undefined,
   });
+
   // 선택 아이템 인덳스
   const [selectedItem, setSelectedItem] = useState(0);
+
+  function onNext(data: AllOptionType) {
+    const newOption = {
+      id: data.id,
+      name: data.name,
+      price: data.price,
+      imgUrl: data.images?.[0].imgUrl,
+      categoryId: data.categoryId,
+      type: optionTypeName[data.categoryId],
+    };
+    saveOptionData({ newOption });
+  }
+
+  useEffect(() => {
+    setSelectedItem(0);
+    console.log(data);
+  }, [data]);
+
   return (
     !loading && (
       <main className="relative flex-grow">
         <div className="absolute top-0 bottom-0 grid w-full grid-cols-2 lg:grid-cols-12">
           {/* 이미지 영역 */}
-          <div className="lg:col-span-7">
-            <img
-              src={data?.[selectedItem].images[0].imgUrl ?? ''}
-              className="object-cover w-full h-full"
-              alt="palisade"
-            />
+          <div className="lg:col-span-7 flex flex-col justify-center">
+            {Number(step) === EXTERIOR_COLOR_STEP ? (
+              <RotateCarImage
+                images={getRotateImages({
+                  url: data?.[selectedItem].images[0].imgUrl ?? '',
+                  count: 60,
+                })}
+                className="h-fit"
+              />
+            ) : (
+              <img
+                src={data?.[selectedItem].images[0].imgUrl ?? ''}
+                className="w-full h-full object-cover"
+                alt="palisade"
+              />
+            )}
           </div>
           {/* 옵션 선택 영역 */}
           <div className="flex flex-col max-w-lg lg:col-span-5">
             <SelectOptionMessage step={Number(step)} />
             <SelectOptionListContainer>
-              {data?.map((item: AllOptionType, index) => (
-                <OptionCard
-                  key={`OptionCard-${item.name}`}
-                  isActive={selectedItem === index}
-                  onClick={() => {
-                    setSelectedItem(index);
-                  }}
-                  item={item}
-                />
-              ))}
+              {data
+                ?.sort((a, b) => b.rate - a.rate)
+                .map((item: AllOptionType, index) => (
+                  <OptionCard
+                    key={`OptionCard-${item.name}`}
+                    isActive={selectedItem === index}
+                    onClick={() => {
+                      setSelectedItem(index);
+                    }}
+                    item={item}
+                  />
+                ))}
             </SelectOptionListContainer>
             <SelectOptionFooter
-              {...{ mode, id, step, data: data[selectedItem] }}
+              {...{ mode, id, step, onNext: () => onNext(data[selectedItem]) }}
             />
           </div>
         </div>

--- a/client/src/pages/making/select/index.ts
+++ b/client/src/pages/making/select/index.ts
@@ -1,2 +1,5 @@
 export { default as SelectOptionPage } from './SelectOptionPage';
 export { default as SelectMultiOptionPage } from './SelectMultiOptionPage';
+export { default as SelectOptionFooter } from './SelectOptionFooter';
+export { default as SelectOptionMessage } from './SelectOptionMessage';
+export { default as SelectOptionListContainer } from './SelectOptionListContainer';

--- a/client/src/pages/making/select/index.ts
+++ b/client/src/pages/making/select/index.ts
@@ -1,0 +1,2 @@
+export { default as SelectOptionPage } from './SelectOptionPage';
+export { default as SelectMultiOptionPage } from './SelectMultiOptionPage';

--- a/client/src/pages/making/select/type.ts
+++ b/client/src/pages/making/select/type.ts
@@ -1,0 +1,6 @@
+import { AllOptionType } from '@/types/option.ts';
+
+export interface SelectOptionPageProps {
+  data: AllOptionType[];
+  isLoading: boolean;
+}

--- a/client/src/pages/making/type.ts
+++ b/client/src/pages/making/type.ts
@@ -2,6 +2,7 @@ export type ColorType = 'exterior' | 'interior';
 export type ColorTextType = '외부' | '내부';
 
 export interface OptionType {
+  id: number;
   name: string;
   imgUrl: string;
   type?: string;


### PR DESCRIPTION
## 📕 요약

closed #251 

## 📗 작업 내용
![image](https://github.com/softeerbootcamp-2nd/H8-YoungCha/assets/74632599/9f1f2583-d5ac-4834-a150-0920560db026)

- [x] 옵션 선택 카드 다중옵션 케이스 처리
- [x] 옵션 선택 페이지 카테고라이징 기능 추가
- [x] 외장 색상 선택 페이지 360도 이미지 추가
- [x] 가이드 모드에서도 API 동작하게 수정
  - 현재 쿼리스트링에 임의의 값을 설정해 두었는데, 가이드모드 context와 연결해야합니다.
- [x] 옵션 타입 변경
- [x]  그 외에 자잘한 수정

## 📘 PR 특이 사항

#### 타입 변경

다음과 같은 이유로 OptionType에 id값을 추가하였습니다. 
- 페이지 이동시, Context의 옵션 상태를 있는 값을 기본 값으로 설정하기 위해 필요
- 옵션 다중 선택에서 옵션을 식별하기 위해 id 값을 상태로 저장하기 때문에 초기값을 가져올 때 필요
- 내장 색상 API 호출시 외장 색상 ID가 필요

#### 데이터 패칭 코드 중복 처리
현재 SelectOptionPage와 SelectMultiOptionPage에서 데이터를 패칭하는 코드가 중복됩니다(22 lines). 중복 코드는 다음과 같습니다. 
```ts
 const { data, loading } = useFetch<AllOptionType[]>({
    url,
    params:
      mode === 'guide'
        ? ({
            keyword1Id: '1',
            keyword2Id: '2',
            keyword3Id: '3',
            age: '2',
            gender: '0',
            exteriorColorId:
              Number(step) === INTERIOR_COLOR_STEP
                ? userSelectedOptionData.colors.options.exteriorColor.id.toString()
                : '0',
          } as Record<string, string>)
        : Number(step) === INTERIOR_COLOR_STEP
        ? ({
            exteriorColorId:
              userSelectedOptionData.colors.options.exteriorColor.id.toString(),
          } as Record<string, string>)
        : undefined,
  });
```

이러한 중복 코드를 줄이기 위해서는 MakingPage에서 데이터를 패칭하는 로직을 가지고 데이터를 SelectOptionPage와 SelectMultiOptionPage로 props로 내려주면 되는데, 이러한 처리를 해야할지 아니면 그대로 놔두어도 괜찮을지 의견을 구하고 싶습니다!