### PR TITLE
[FE] 가이드모드 키워드 선택시 데이터 요청

### DIFF
--- a/client/src/hooks/useSelectOption.ts
+++ b/client/src/hooks/useSelectOption.ts
@@ -11,12 +11,19 @@ function useSelectOption() {
     INITIAL_USER_SELECTED_DATA
   );
 
-  function saveOptionData({ newOption }: { newOption: OptionType }) {
+  function saveOptionData({
+    newOption,
+    newOptions,
+  }: {
+    newOption?: OptionType;
+    newOptions?: OptionType[];
+  }) {
     setUserSelectedOptionData((prev) => {
       const newData = { ...prev };
       const newStorageData = getNewUserOptionData({
         newData,
         newOption,
+        newOptions,
       });
       setStorage<UserSelectedOptionDataType>({
         key: 'optionData',

--- a/client/src/hooks/useSelectOption.ts
+++ b/client/src/hooks/useSelectOption.ts
@@ -4,6 +4,7 @@ import getNewUserOptionData from '@/utils/getNewOptionData';
 import { useEffect, useState } from 'react';
 import { UserSelectedOptionDataType } from '../pages/making/type';
 import { getStorage, setStorage } from '@/utils/optionStorage';
+import getNewUserOptionsData from '../utils/getNewOptionsData';
 
 // 상태 설정, storage 저장
 function useSelectOption() {
@@ -20,11 +21,9 @@ function useSelectOption() {
   }) {
     setUserSelectedOptionData((prev) => {
       const newData = { ...prev };
-      const newStorageData = getNewUserOptionData({
-        newData,
-        newOption,
-        newOptions,
-      });
+      const newStorageData = newOption
+        ? getNewUserOptionData({ newData, newOption })
+        : getNewUserOptionsData({ newData, newOptions });
       setStorage<UserSelectedOptionDataType>({
         key: 'optionData',
         value: newStorageData,

--- a/client/src/pages/guide/CompleteGuide.tsx
+++ b/client/src/pages/guide/CompleteGuide.tsx
@@ -2,20 +2,32 @@ import Button from '@/components/Button';
 import { TEXT } from './constant';
 import { Link, useParams } from 'react-router-dom';
 import Confetti from '@/components/Confetti';
+import RotateCarImage from '@/components/RotateCarImage';
+import getRotateImages from '@/utils/getRotateImages';
+import { UserSelectedOptionDataType } from '../making/type';
+import { getStorage } from '@/utils/optionStorage';
+import { INITIAL_USER_SELECTED_DATA } from '../making/constant';
 
 function CompleteGuide() {
   const { id } = useParams();
+  const userSelectedOptionData = getStorage({
+    key: 'optionData',
+    initalValue: INITIAL_USER_SELECTED_DATA,
+  }) as UserSelectedOptionDataType;
 
   return (
     <>
       <Confetti particleCount={120} circleParticleCount={60} />
       <div className="flex flex-col items-center w-full gap-16px">
-        <img
-          src="/src/assets/mock/images/palisade.png"
-          alt="palisade"
-          width={400}
-          height={300}
-        />
+        <div className="w-450px">
+          <RotateCarImage
+            images={getRotateImages({
+              url: userSelectedOptionData?.colors.options.exteriorColor?.imgUrl,
+              count: 60,
+            })}
+          />
+        </div>
+
         <h1 className="font-hsans-head text-32px font-medium leading-[44.8px] tracking-[-1.28px]">
           {TEXT.TITLE.complete}
         </h1>

--- a/client/src/pages/guide/CompleteGuideWithLoading.tsx
+++ b/client/src/pages/guide/CompleteGuideWithLoading.tsx
@@ -9,6 +9,7 @@ import useSelectOption from '@/hooks/useSelectOption';
 import { optionTypeName } from '@/constant';
 import { useLocation } from 'react-router-dom';
 import { AgeType, GenderType } from './type';
+import { setStorage } from '@/utils/optionStorage';
 
 const TRIM_ID = 2;
 
@@ -46,28 +47,23 @@ function CompleteGuideWithLoading() {
   }
 
   async function getUserGuideOptions() {
-    const [age, gender, keyword1Id, keyword2Id, keyword3Id] = [
-      keywordId[selectedAge!],
-      keywordId[selectedGender!],
-      keywordId[selectedKeyword[0] as keyof typeof keywordId],
-      keywordId[selectedKeyword[1] as keyof typeof keywordId],
-      keywordId[selectedKeyword[2] as keyof typeof keywordId],
-    ];
+    const params = {
+      age: keywordId[selectedAge!],
+      gender: keywordId[selectedGender!],
+      keyword1Id: keywordId[selectedKeyword[0] as keyof typeof keywordId],
+      keyword2Id: keywordId[selectedKeyword[1] as keyof typeof keywordId],
+      keyword3Id: keywordId[selectedKeyword[2] as keyof typeof keywordId],
+      exteriorColorId: '',
+    };
+
     const exterirColorData = await get<AllGuideOptionType[]>({
       url: `/car-make/${TRIM_ID}/guide/exterior-color`,
-      params: { age, gender, keyword1Id, keyword2Id, keyword3Id },
+      params: params,
     });
-    const exteriorColorId = String(
+    params.exteriorColorId = String(
       exterirColorData?.filter((data) => data.checked)[0].id
     );
-    const params = {
-      age,
-      gender,
-      keyword1Id,
-      keyword2Id,
-      keyword3Id,
-      exteriorColorId,
-    };
+
     const urls = [
       {
         url: `/car-make/${TRIM_ID}/guide/wheel`,
@@ -95,6 +91,10 @@ function CompleteGuideWithLoading() {
       },
     ];
 
+    setStorage({
+      key: 'keywords',
+      value: params,
+    });
     const options = await Promise.all(
       urls.map(({ url, params }) => get<AllGuideOptionType>({ url, params }))
     );

--- a/client/src/pages/making/complete/CompleteOptionPage.tsx
+++ b/client/src/pages/making/complete/CompleteOptionPage.tsx
@@ -29,7 +29,8 @@ function CompleteOptionPage() {
       option,
     }))
   );
-
+  console.log(userSelectedOptionData);
+  console.log(userSelectedOptionData?.colors.options.exteriorColor.imgUrl);
   return (
     <div>
       <Confetti particleCount={120} circleParticleCount={60} />
@@ -38,13 +39,25 @@ function CompleteOptionPage() {
           <h1 className="whitespace-pre-line text-34px font-medium leading-[47.6px] tracking-[-1.36px] font-hsans-head text-grey-black text-center">
             {COMPLETE_OPTION_PAGE_TITLE}
           </h1>
-          <RotateCarImage
-            images={getRotateImages({
-              url: 'https://www.hyundai.com/contents/vr360/LX06/exterior/WC9/colorchip-exterior.png',
-              count: 60,
-            })}
-            className={`w-[600px] h-[400px]`}
-          />
+          <div className={`w-700px h-400px flex justify-center items-center`}>
+            {selectedColorType === 'exterior' ? (
+              <RotateCarImage
+                images={getRotateImages({
+                  url: userSelectedOptionData?.colors.options.exteriorColor
+                    .imgUrl,
+                  count: 60,
+                })}
+              />
+            ) : (
+              <img
+                src={
+                  userSelectedOptionData?.colors.options.interiorColor.imgUrl
+                }
+                alt="interior"
+              />
+            )}
+          </div>
+
           <div className="flex">
             {CAR_COLOR.map(({ text, type }) => (
               <button

--- a/client/src/pages/making/complete/CompleteOptionPage.tsx
+++ b/client/src/pages/making/complete/CompleteOptionPage.tsx
@@ -1,8 +1,16 @@
-import { useContext, useState } from 'react';
+import { useContext, useEffect, useState } from 'react';
 import Button from '@/components/Button';
 import SummaryOptionsBox from './SummaryOptionsBox';
-import { CAR_COLOR, COMPLETE_OPTION_PAGE_TITLE } from '../constant';
-import { ColorType, OptionGroupType } from '../type';
+import {
+  CAR_COLOR,
+  COMPLETE_OPTION_PAGE_TITLE,
+  INITIAL_USER_SELECTED_DATA,
+} from '../constant';
+import {
+  ColorType,
+  OptionGroupType,
+  UserSelectedOptionDataType,
+} from '../type';
 import DetailOptionBox from '../detail-option-box/DetailOptionBox';
 import DetailSelectOptionBox from '../detail-option-box/DetailSelectOptionBox';
 import DetailBasicOptionBox from '../detail-option-box/DetailBasicOptionBox';
@@ -13,6 +21,7 @@ import { UserSelectedOptionDataContext } from '..';
 import getOptionGroupTotalPrice from '@/utils/getTotalPrice';
 import getOptionGroupsTotalPrice from '@/utils/getTotalPrice';
 import { formatPrice } from '@/utils';
+import { getStorage } from '@/utils/optionStorage';
 
 function CompleteOptionPage() {
   const [selectedColorType, setSelectedColorType] =
@@ -20,7 +29,19 @@ function CompleteOptionPage() {
   const activeColor = 'text-white bg-main-blue';
   const inactiveColor = 'text-main-blue bg-grey-001';
 
-  const { userSelectedOptionData } = useContext(UserSelectedOptionDataContext);
+  const { userSelectedOptionData, setUserSelectedOptionData } = useContext(
+    UserSelectedOptionDataContext
+  );
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    const loadData = getStorage({
+      key: 'optionData',
+      initalValue: INITIAL_USER_SELECTED_DATA,
+    }) as UserSelectedOptionDataType;
+    setUserSelectedOptionData(loadData);
+    setIsLoading(false);
+  }, []);
 
   const totalPrice = getOptionGroupsTotalPrice(
     userSelectedOptionData.mainOptions.options,
@@ -30,128 +51,141 @@ function CompleteOptionPage() {
     }))
   );
   return (
-    <div>
-      <Confetti particleCount={120} circleParticleCount={60} />
-      <div className="flex flex-col items-center w-full m-auto pt-60px gap-60px max-w-7xl px-128px pb-70px">
-        <div className="flex flex-col items-center w-full">
-          <h1 className="whitespace-pre-line text-34px font-medium leading-[47.6px] tracking-[-1.36px] font-hsans-head text-grey-black text-center">
-            {COMPLETE_OPTION_PAGE_TITLE}
-          </h1>
-          <div className={`w-700px h-400px flex justify-center items-center`}>
-            {selectedColorType === 'exterior' ? (
-              <RotateCarImage
-                images={getRotateImages({
-                  url: userSelectedOptionData?.colors.options.exteriorColor
-                    .imgUrl,
-                  count: 60,
-                })}
-              />
-            ) : (
-              <img
-                src={
-                  userSelectedOptionData?.colors.options.interiorColor.imgUrl
-                }
-                alt="interior"
-              />
-            )}
-          </div>
-
-          <div className="flex">
-            {CAR_COLOR.map(({ text, type }) => (
-              <button
-                className={`${
-                  selectedColorType === type ? activeColor : inactiveColor
-                } py-8px px-32px title4`}
-                key={type}
-                onClick={() => setSelectedColorType(type)}
+    <>
+      {!isLoading && (
+        <div>
+          <Confetti particleCount={120} circleParticleCount={60} />
+          <div className="flex flex-col items-center w-full m-auto pt-60px gap-60px max-w-7xl px-128px pb-70px">
+            <div className="flex flex-col items-center w-full">
+              <h1 className="whitespace-pre-line text-34px font-medium leading-[47.6px] tracking-[-1.36px] font-hsans-head text-grey-black text-center">
+                {COMPLETE_OPTION_PAGE_TITLE}
+              </h1>
+              <div
+                className={`w-700px h-400px flex justify-center items-center`}
               >
-                {text}
-              </button>
-            ))}
-          </div>
-        </div>
+                {selectedColorType === 'exterior' ? (
+                  <RotateCarImage
+                    images={getRotateImages({
+                      url: userSelectedOptionData?.colors.options.exteriorColor
+                        ?.imgUrl,
+                      count: 60,
+                    })}
+                  />
+                ) : (
+                  <img
+                    src={
+                      userSelectedOptionData?.colors.options.interiorColor
+                        .imgUrl
+                    }
+                    alt="interior"
+                  />
+                )}
+              </div>
 
-        <div className="w-full">
-          <div className="flex items-center justify-between h-68px px-24px">
-            <span className="title3 text-grey-black">견적 요약</span>
-            <div className="flex items-center gap-14px">
-              <span className="title4 text-grey-black">차량 총 견적 금액</span>
-              <span className="font-hsans-head text-34px font-medium leading-[44.2px] tracking-[-1.02px] text-grey-black">
-                {formatPrice(totalPrice)}
-              </span>
+              <div className="flex">
+                {CAR_COLOR.map(({ text, type }) => (
+                  <button
+                    className={`${
+                      selectedColorType === type ? activeColor : inactiveColor
+                    } py-8px px-32px title4`}
+                    key={type}
+                    onClick={() => setSelectedColorType(type)}
+                  >
+                    {text}
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            <div className="w-full">
+              <div className="flex items-center justify-between h-68px px-24px">
+                <span className="title3 text-grey-black">견적 요약</span>
+                <div className="flex items-center gap-14px">
+                  <span className="title4 text-grey-black">
+                    차량 총 견적 금액
+                  </span>
+                  <span className="font-hsans-head text-34px font-medium leading-[44.2px] tracking-[-1.02px] text-grey-black">
+                    {formatPrice(totalPrice)}
+                  </span>
+                </div>
+              </div>
+
+              {Object.values(userSelectedOptionData).map((optionGroup) => {
+                const { title, options } = optionGroup as OptionGroupType;
+
+                const totalGroupPrice = getOptionGroupTotalPrice(options);
+
+                return (
+                  <SummaryOptionsBox
+                    title={title}
+                    price={totalGroupPrice}
+                    key={title}
+                  >
+                    {Object.values(options).map(
+                      ({ type, name, price }, index) => {
+                        const isDuplicatedType = title === '옵션' && index > 0;
+                        return (
+                          <SummaryOptionsBox.Option
+                            type={isDuplicatedType ? '' : type}
+                            name={name}
+                            price={price!}
+                            key={name}
+                          />
+                        );
+                      }
+                    )}
+                  </SummaryOptionsBox>
+                );
+              })}
+            </div>
+
+            <div className="flex justify-between w-full">
+              <Button size="xl" color="main-blue">
+                구매 상담 신청
+              </Button>
+              <Button size="xl" color="white">
+                시승 신청하기
+              </Button>
+              <Button size="xl" color="grey">
+                공유하기
+              </Button>
+              <Button size="xl" color="grey">
+                저장하기
+              </Button>
+            </div>
+
+            <div className="flex flex-col w-full gap-60px">
+              <div className="flex items-center justify-between h-68px px-24px">
+                <span className="title3 text-grey-black">견적 자세히 보기</span>
+                <div className="flex items-center gap-14px">
+                  <span className="title4 text-grey-black">
+                    차량 총 견적 금액
+                  </span>
+                  <span className="font-hsans-head text-34px font-medium leading-[44.2px] tracking-[-1.02px] text-[#36383C]">
+                    {formatPrice(totalPrice)}
+                  </span>
+                </div>
+              </div>
+
+              <div className="flex flex-col gap-60px">
+                {Object.values(userSelectedOptionData.mainOptions.options).map(
+                  (option) => (
+                    <DetailOptionBox option={option} key={option.name} />
+                  )
+                )}
+                {Object.values(userSelectedOptionData.colors.options).map(
+                  (option) => (
+                    <DetailOptionBox option={option} key={option.name} />
+                  )
+                )}
+                <DetailBasicOptionBox />
+                <DetailSelectOptionBox />
+              </div>
             </div>
           </div>
-
-          {Object.values(userSelectedOptionData).map((optionGroup) => {
-            const { title, options } = optionGroup as OptionGroupType;
-
-            const totalGroupPrice = getOptionGroupTotalPrice(options);
-
-            return (
-              <SummaryOptionsBox
-                title={title}
-                price={totalGroupPrice}
-                key={title}
-              >
-                {Object.values(options).map(({ type, name, price }, index) => {
-                  const isDuplicatedType = title === '옵션' && index > 0;
-                  return (
-                    <SummaryOptionsBox.Option
-                      type={isDuplicatedType ? '' : type}
-                      name={name}
-                      price={price!}
-                      key={name}
-                    />
-                  );
-                })}
-              </SummaryOptionsBox>
-            );
-          })}
         </div>
-
-        <div className="flex justify-between w-full">
-          <Button size="xl" color="main-blue">
-            구매 상담 신청
-          </Button>
-          <Button size="xl" color="white">
-            시승 신청하기
-          </Button>
-          <Button size="xl" color="grey">
-            공유하기
-          </Button>
-          <Button size="xl" color="grey">
-            저장하기
-          </Button>
-        </div>
-
-        <div className="flex flex-col w-full gap-60px">
-          <div className="flex items-center justify-between h-68px px-24px">
-            <span className="title3 text-grey-black">견적 자세히 보기</span>
-            <div className="flex items-center gap-14px">
-              <span className="title4 text-grey-black">차량 총 견적 금액</span>
-              <span className="font-hsans-head text-34px font-medium leading-[44.2px] tracking-[-1.02px] text-[#36383C]">
-                {formatPrice(totalPrice)}
-              </span>
-            </div>
-          </div>
-
-          <div className="flex flex-col gap-60px">
-            {Object.values(userSelectedOptionData.mainOptions.options).map(
-              (option) => (
-                <DetailOptionBox option={option} key={option.name} />
-              )
-            )}
-            {Object.values(userSelectedOptionData.colors.options).map(
-              (option) => (
-                <DetailOptionBox option={option} key={option.name} />
-              )
-            )}
-            <DetailBasicOptionBox />
-            <DetailSelectOptionBox />
-          </div>
-        </div>
-      </div>
-    </div>
+      )}
+    </>
   );
 }
 

--- a/client/src/pages/making/complete/CompleteOptionPage.tsx
+++ b/client/src/pages/making/complete/CompleteOptionPage.tsx
@@ -139,7 +139,7 @@ function CompleteOptionPage() {
               })}
             </div>
 
-            <div className="flex justify-between w-full">
+            <div className="flex justify-between w-full gap-x-16px">
               <Button size="xl" color="main-blue">
                 구매 상담 신청
               </Button>

--- a/client/src/pages/making/complete/CompleteOptionPage.tsx
+++ b/client/src/pages/making/complete/CompleteOptionPage.tsx
@@ -29,8 +29,6 @@ function CompleteOptionPage() {
       option,
     }))
   );
-  console.log(userSelectedOptionData);
-  console.log(userSelectedOptionData?.colors.options.exteriorColor.imgUrl);
   return (
     <div>
       <Confetti particleCount={120} circleParticleCount={60} />

--- a/client/src/pages/making/constant.ts
+++ b/client/src/pages/making/constant.ts
@@ -43,3 +43,12 @@ export const INITIAL_USER_SELECTED_DATA: UserSelectedOptionDataType = {
     options: [],
   },
 };
+
+export const INITIAL_KEYWORDS = {
+  keyword1Id: '1',
+  keyword2Id: '2',
+  keyword3Id: '3',
+  age: '2',
+  gender: '0',
+  exteriorColorId: '0',
+} as Record<string, string>;

--- a/client/src/pages/making/detail-option-box/DetailBasicOptionBox.tsx
+++ b/client/src/pages/making/detail-option-box/DetailBasicOptionBox.tsx
@@ -17,17 +17,11 @@ function DetailBasicOptionBox() {
     categoryId: BasicOptionsId[selectedOptionFilter],
     currentSize,
   });
-
+  console.log(basicOptions);
   function handleMoreOptionClick() {
     setCurrentSize((prev) => prev + OPTION_SIZE);
   }
 
-  function isSelectOption(categoryId: number) {
-    return (
-      BasicOptionsId[selectedOptionFilter] === -1 ||
-      BasicOptionsId[selectedOptionFilter] === categoryId
-    );
-  }
   return (
     <DetailOption>
       <DetailOption.Header
@@ -38,14 +32,12 @@ function DetailBasicOptionBox() {
         selectedOption={selectedOptionFilter}
         onClick={(option) => setSelectedOptionFilter(option)}
       />
-      {basicOptions?.contents
-        ?.filter((option) => isSelectOption(option.categoryId!))
-        .map((option) => (
-          <DetailOption.List
-            option={{ ...option, type: '기본 포함 품목' }}
-            key={option.name}
-          />
-        ))}
+      {basicOptions?.contents?.map((option) => (
+        <DetailOption.List
+          option={{ ...option, type: '기본 포함 품목' }}
+          key={option.name}
+        />
+      ))}
 
       {!basicOptions.last && (
         <div className="flex justify-center">

--- a/client/src/pages/making/detail-option-box/DetailBasicOptionBox.tsx
+++ b/client/src/pages/making/detail-option-box/DetailBasicOptionBox.tsx
@@ -17,7 +17,6 @@ function DetailBasicOptionBox() {
     categoryId: BasicOptionsId[selectedOptionFilter],
     currentSize,
   });
-  console.log(basicOptions);
   function handleMoreOptionClick() {
     setCurrentSize((prev) => prev + OPTION_SIZE);
   }

--- a/client/src/pages/making/detail-option-box/DetailSelectOptionBox.tsx
+++ b/client/src/pages/making/detail-option-box/DetailSelectOptionBox.tsx
@@ -1,20 +1,20 @@
-import { useState } from 'react';
+import { useContext, useState } from 'react';
 import DetailOption from './DetailOption';
-import { mockUserSelectedOptionData } from '@/assets/mock/mock';
 import { SelectOptionsId } from '@/constant';
 import { SelectOptionFilterType } from '@/types';
+import { UserSelectedOptionDataContext } from '..';
 
 function DetailSelectOptionBox() {
   const [selectedOptionFilter, setSelectedOptionFilter] =
     useState<SelectOptionFilterType>('전체');
-
+  const { userSelectedOptionData } = useContext(UserSelectedOptionDataContext);
   function isSelectOption(categoryId: number) {
     return (
-      SelectOptionsId[selectedOptionFilter] === -1 ||
+      SelectOptionsId[selectedOptionFilter] === 0 ||
       SelectOptionsId[selectedOptionFilter] === categoryId
     );
   }
-  const totalPrice = mockUserSelectedOptionData.selectedOptions.options.reduce(
+  const totalPrice = userSelectedOptionData.selectedOptions.options.reduce(
     (sum, option) => sum + option.price!,
     0
   );
@@ -29,7 +29,7 @@ function DetailSelectOptionBox() {
         selectedOption={selectedOptionFilter}
         onClick={(option) => setSelectedOptionFilter(option)}
       />
-      {mockUserSelectedOptionData.selectedOptions.options
+      {userSelectedOptionData.selectedOptions.options
         .filter((option) => isSelectOption(option.categoryId!))
         .map((option) => (
           <DetailOption.List option={option} key={option.name} />

--- a/client/src/pages/making/index.tsx
+++ b/client/src/pages/making/index.tsx
@@ -16,7 +16,13 @@ import {
 
 export interface UserSelectedOptionDataContextType {
   userSelectedOptionData: UserSelectedOptionDataType;
-  saveOptionData: ({ newOption }: { newOption: OptionType }) => void;
+  saveOptionData: ({
+    newOption,
+    newOptions,
+  }: {
+    newOption?: OptionType;
+    newOptions?: OptionType[];
+  }) => void;
 }
 
 export const UserSelectedOptionDataContext =
@@ -52,17 +58,16 @@ function MakingPage() {
             gender: '0',
             exteriorColorId:
               Number(step) === INTERIOR_COLOR_STEP
-                ? userSelectedOptionData.colors.options.exteriorColor.id.toString()
+                ? userSelectedOptionData.colors.options.exteriorColor?.id.toString()
                 : '0',
           } as Record<string, string>)
         : Number(step) === INTERIOR_COLOR_STEP
         ? ({
             exteriorColorId:
-              userSelectedOptionData.colors.options.exteriorColor.id.toString(),
+              userSelectedOptionData.colors.options.exteriorColor?.id.toString(),
           } as Record<string, string>)
         : undefined,
   });
-
   if (Number(step) === LAST_STEP - 1)
     return <SelectMultiOptionPage {...{ data, isLoading }} />;
 

--- a/client/src/pages/making/index.tsx
+++ b/client/src/pages/making/index.tsx
@@ -37,7 +37,6 @@ function MakingPage() {
   const { step, mode } = useParams() as PathParamsType;
   const { state } = useLocation();
 
-  console.log(state);
   if (Number(step) === LAST_STEP) {
     return state?.isGuide ? (
       <CompleteOptionPage />
@@ -48,7 +47,6 @@ function MakingPage() {
 
   const { userSelectedOptionData } = useContext(UserSelectedOptionDataContext);
   const url = `/car-make/2/${mode}/${PROGRESS_LIST[Number(step) - 1].path}`;
-  console.log(state);
   const { data, loading: isLoading } = useFetch<AllOptionType[]>({
     url,
     params:

--- a/client/src/pages/making/index.tsx
+++ b/client/src/pages/making/index.tsx
@@ -16,6 +16,7 @@ import {
 
 export interface UserSelectedOptionDataContextType {
   userSelectedOptionData: UserSelectedOptionDataType;
+  setUserSelectedOptionData: (data: UserSelectedOptionDataType) => void;
   saveOptionData: ({
     newOption,
     newOptions,
@@ -28,6 +29,7 @@ export interface UserSelectedOptionDataContextType {
 export const UserSelectedOptionDataContext =
   createContext<UserSelectedOptionDataContextType>({
     userSelectedOptionData: INITIAL_USER_SELECTED_DATA,
+    setUserSelectedOptionData: () => {},
     saveOptionData: () => {},
   });
 
@@ -35,6 +37,7 @@ function MakingPage() {
   const { step, mode } = useParams() as PathParamsType;
   const { state } = useLocation();
 
+  console.log(state);
   if (Number(step) === LAST_STEP) {
     return state?.isGuide ? (
       <CompleteOptionPage />
@@ -45,7 +48,7 @@ function MakingPage() {
 
   const { userSelectedOptionData } = useContext(UserSelectedOptionDataContext);
   const url = `/car-make/2/${mode}/${PROGRESS_LIST[Number(step) - 1].path}`;
-
+  console.log(state);
   const { data, loading: isLoading } = useFetch<AllOptionType[]>({
     url,
     params:
@@ -75,12 +78,14 @@ function MakingPage() {
 }
 
 export default function MakingPageWithProvider() {
-  const { userSelectedOptionData, saveOptionData } = useSelectOption();
+  const { userSelectedOptionData, setUserSelectedOptionData, saveOptionData } =
+    useSelectOption();
 
   return (
     <UserSelectedOptionDataContext.Provider
       value={{
         userSelectedOptionData,
+        setUserSelectedOptionData,
         saveOptionData,
       }}
     >

--- a/client/src/pages/making/index.tsx
+++ b/client/src/pages/making/index.tsx
@@ -4,7 +4,11 @@ import { SelectOptionPage, SelectMultiOptionPage } from './select';
 import CompleteOptionPage from './complete/CompleteOptionPage';
 import CompleteOptionPageWithLoading from './complete/CompleteOptionPageWithLoading';
 import useSelectOption from '@/hooks/useSelectOption.ts';
-import { INITIAL_USER_SELECTED_DATA, LAST_STEP } from './constant';
+import {
+  INITIAL_KEYWORDS,
+  INITIAL_USER_SELECTED_DATA,
+  LAST_STEP,
+} from './constant';
 import { OptionType, UserSelectedOptionDataType } from './type';
 import { PathParamsType } from '@/types/router.ts';
 import useFetch from '@/hooks/useFetch.ts';
@@ -13,6 +17,7 @@ import {
   INTERIOR_COLOR_STEP,
   PROGRESS_LIST,
 } from '@/pages/making/select/constant.ts';
+import { getStorage } from '@/utils/optionStorage.ts';
 
 export interface UserSelectedOptionDataContextType {
   userSelectedOptionData: UserSelectedOptionDataType;
@@ -47,28 +52,30 @@ function MakingPage() {
 
   const { userSelectedOptionData } = useContext(UserSelectedOptionDataContext);
   const url = `/car-make/2/${mode}/${PROGRESS_LIST[Number(step) - 1].path}`;
-  const { data, loading: isLoading } = useFetch<AllOptionType[]>({
-    url,
-    params:
-      mode === 'guide'
-        ? ({
-            keyword1Id: '1',
-            keyword2Id: '2',
-            keyword3Id: '3',
-            age: '2',
-            gender: '0',
-            exteriorColorId:
-              Number(step) === INTERIOR_COLOR_STEP
-                ? userSelectedOptionData.colors.options.exteriorColor?.id.toString()
-                : '0',
-          } as Record<string, string>)
-        : Number(step) === INTERIOR_COLOR_STEP
+
+  const getParams = () => {
+    const keywords = getStorage({
+      key: 'keywords',
+      initalValue: INITIAL_KEYWORDS,
+    });
+
+    if (mode === 'guide') {
+      return keywords;
+    }
+    if (mode === 'self') {
+      return Number(step) === INTERIOR_COLOR_STEP
         ? ({
             exteriorColorId:
               userSelectedOptionData.colors.options.exteriorColor?.id.toString(),
           } as Record<string, string>)
-        : undefined,
+        : undefined;
+    }
+  };
+  const { data, loading: isLoading } = useFetch<AllOptionType[]>({
+    url,
+    params: getParams(),
   });
+
   if (Number(step) === LAST_STEP - 1)
     return <SelectMultiOptionPage {...{ data, isLoading }} />;
 

--- a/client/src/pages/making/select/SelectMultiOptionPage.tsx
+++ b/client/src/pages/making/select/SelectMultiOptionPage.tsx
@@ -26,12 +26,25 @@ function SelectMultiOptionPage({ data, isLoading }: SelectOptionPageProps) {
   const [categorizedData, setCategorizedData] = useState(
     {} as { [key: string]: AllOptionType[] }
   );
-  const { saveOptionData } = useContext(UserSelectedOptionDataContext);
+  const { userSelectedOptionData, saveOptionData } = useContext(
+    UserSelectedOptionDataContext
+  );
   function onNext() {
-    // data: AllOptionType[]
-    // const newOption = data?.filter((item) => selectedItems.includes(item.id));
-    //   TODO: 배열 저장
     navigate(`/model/${id}/making/${mode}/${Number(step) + 1}`);
+  }
+  function getSelectedItemIndex() {
+    const itemIndex: number[] = [];
+
+    Object.values(userSelectedOptionData.selectedOptions.options).forEach(
+      ({ id, categoryId }) => {
+        if (categoryId === data[0].id) {
+          data.forEach((item, index) => {
+            if (id === item.id) itemIndex.push(index);
+          });
+        }
+      }
+    );
+    return itemIndex;
   }
 
   useEffect(() => {
@@ -46,12 +59,13 @@ function SelectMultiOptionPage({ data, isLoading }: SelectOptionPageProps) {
       },
       {} as { [key: string]: AllOptionType[] }
     );
+    const itemIndexs = getSelectedItemIndex();
     setCategorizedData(newCategorizedData);
+    setSelectedItems(itemIndexs);
   }, [data]);
 
   useEffect(() => {
-    console.log(data);
-    console.log(selectedItems);
+    if (!Array.isArray(data)) return;
     const newOptions = selectedItems.map((optionId) => {
       const optionIndex = data?.findIndex((item) => item.id === optionId);
       return {
@@ -64,7 +78,7 @@ function SelectMultiOptionPage({ data, isLoading }: SelectOptionPageProps) {
       };
     });
     saveOptionData({ newOptions });
-  }, [selectedItems]);
+  }, [selectedItems, data]);
 
   return (
     <main className="relative flex-grow">

--- a/client/src/pages/making/select/SelectMultiOptionPage.tsx
+++ b/client/src/pages/making/select/SelectMultiOptionPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useContext, useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import OptionCard from '@/components/OptionCard';
 import {
@@ -11,6 +11,8 @@ import { AllOptionType } from '@/types/option';
 import { SelectOptionPageProps } from '@/pages/making/select/type.ts';
 import Spinner from '@/components/Spinner';
 import Skeleton from '@/components/OptionCard/Skeleton.tsx';
+import { UserSelectedOptionDataContext } from '..';
+import { optionTypeName } from '@/constant';
 
 const CATEGORY = ['시스템', '온도관리', '외부장치', '내부장치'];
 
@@ -24,7 +26,7 @@ function SelectMultiOptionPage({ data, isLoading }: SelectOptionPageProps) {
   const [categorizedData, setCategorizedData] = useState(
     {} as { [key: string]: AllOptionType[] }
   );
-
+  const { saveOptionData } = useContext(UserSelectedOptionDataContext);
   function onNext() {
     // data: AllOptionType[]
     // const newOption = data?.filter((item) => selectedItems.includes(item.id));
@@ -47,11 +49,28 @@ function SelectMultiOptionPage({ data, isLoading }: SelectOptionPageProps) {
     setCategorizedData(newCategorizedData);
   }, [data]);
 
+  useEffect(() => {
+    console.log(data);
+    console.log(selectedItems);
+    const newOptions = selectedItems.map((optionId) => {
+      const optionIndex = data?.findIndex((item) => item.id === optionId);
+      return {
+        id: data[optionIndex].id,
+        name: data[optionIndex].name,
+        price: data[optionIndex].price,
+        imgUrl: data[optionIndex].images?.[0].imgUrl,
+        categoryId: data[optionIndex].categoryId,
+        type: optionTypeName[data[optionIndex].categoryId],
+      };
+    });
+    saveOptionData({ newOptions });
+  }, [selectedItems]);
+
   return (
     <main className="relative flex-grow">
       <div className="absolute top-0 bottom-0 grid w-full grid-cols-2 lg:grid-cols-12">
         {/* 이미지 영역 */}
-        <div className="lg:col-span-7 relative flex flex-col justify-center items-center bg-grey-001">
+        <div className="relative flex flex-col items-center justify-center lg:col-span-7 bg-grey-001">
           {isLoading ? (
             <Spinner />
           ) : (
@@ -64,8 +83,8 @@ function SelectMultiOptionPage({ data, isLoading }: SelectOptionPageProps) {
                 className="object-cover w-full h-full"
                 alt="palisade"
               />
-              <div className="absolute bottom-0 left-0 right-0 flex justify-center items-center h-80px drop-shadow-lg">
-                <span className="body1 text-white">
+              <div className="absolute bottom-0 left-0 right-0 flex items-center justify-center h-80px drop-shadow-lg">
+                <span className="text-white body1">
                   {data?.filter((item) => item.id === selectedItem)[0]?.name ??
                     data?.[0].name}
                 </span>

--- a/client/src/pages/making/select/SelectMultiOptionPage.tsx
+++ b/client/src/pages/making/select/SelectMultiOptionPage.tsx
@@ -20,7 +20,7 @@ function SelectMultiOptionPage({ data, isLoading }: SelectOptionPageProps) {
   const { step, mode, id } = useParams() as PathParamsType;
   const navigate = useNavigate();
   const [selectedItem, setSelectedItem] = useState<number>(0);
-  const [selectedItems, setSelectedItems] = useState<number[]>([]);
+  const [selectedItemIds, setSelectedItemIds] = useState<number[]>([]);
 
   const [category, setCategory] = useState('시스템');
   const [categorizedData, setCategorizedData] = useState(
@@ -32,19 +32,11 @@ function SelectMultiOptionPage({ data, isLoading }: SelectOptionPageProps) {
   function onNext() {
     navigate(`/model/${id}/making/${mode}/${Number(step) + 1}`);
   }
-  function getSelectedItemIndex() {
-    const itemIndex: number[] = [];
-
-    Object.values(userSelectedOptionData.selectedOptions.options).forEach(
-      ({ id, categoryId }) => {
-        if (categoryId === data[0].id) {
-          data.forEach((item, index) => {
-            if (id === item.id) itemIndex.push(index);
-          });
-        }
-      }
-    );
-    return itemIndex;
+  function getSelectedItemIds() {
+    const itemIds = Object.values(
+      userSelectedOptionData.selectedOptions.options
+    ).map(({ id }) => id);
+    return itemIds;
   }
 
   useEffect(() => {
@@ -59,15 +51,16 @@ function SelectMultiOptionPage({ data, isLoading }: SelectOptionPageProps) {
       },
       {} as { [key: string]: AllOptionType[] }
     );
-    const itemIndexs = getSelectedItemIndex();
+    const itemIds = getSelectedItemIds();
+
     setCategorizedData(newCategorizedData);
-    setSelectedItems(itemIndexs);
+    setSelectedItemIds(itemIds);
   }, [data]);
 
   useEffect(() => {
     if (!Array.isArray(data)) return;
-    const newOptions = selectedItems.map((optionId) => {
-      const optionIndex = data?.findIndex((item) => item.id === optionId);
+    const newOptions = selectedItemIds.map((id) => {
+      const optionIndex = data.findIndex((item) => item.id === id);
       return {
         id: data[optionIndex].id,
         name: data[optionIndex].name,
@@ -78,7 +71,7 @@ function SelectMultiOptionPage({ data, isLoading }: SelectOptionPageProps) {
       };
     });
     saveOptionData({ newOptions });
-  }, [selectedItems, data]);
+  }, [selectedItemIds, data]);
 
   return (
     <main className="relative flex-grow">
@@ -155,10 +148,10 @@ function SelectMultiOptionPage({ data, isLoading }: SelectOptionPageProps) {
               categorizedData[category]?.map((item: AllOptionType) => (
                 <OptionCard
                   key={`OptionCard-${item.name}`}
-                  isActive={selectedItems.indexOf(item.id) >= 0}
+                  isActive={selectedItemIds.indexOf(item.id) >= 0}
                   onClick={() => {
                     setSelectedItem(item.id);
-                    setSelectedItems((prevState) => {
+                    setSelectedItemIds((prevState) => {
                       if (prevState.indexOf(item.id) >= 0) {
                         return prevState.filter((id) => id !== item.id);
                       } else {

--- a/client/src/pages/making/select/SelectOptionPage.tsx
+++ b/client/src/pages/making/select/SelectOptionPage.tsx
@@ -29,19 +29,7 @@ function SelectOptionPage({ data, isLoading }: SelectOptionPageProps) {
   const [selectedItem, setSelectedItem] = useState(0);
   const [isImageLoading, setIsImageLoading] = useState(true);
 
-  function onNext(data: AllOptionType) {
-    const newOption = {
-      id: data.id,
-      name: data.name,
-      price: data.price,
-      imgUrl: data.images?.[0].imgUrl,
-      categoryId: data.categoryId,
-      type: optionTypeName[data.categoryId],
-    };
-    saveOptionData({ newOption });
-    if (mode === 'guide') {
-      return navigate(`/model/${id}/making/${mode}/${Number(step) + 1}`);
-    }
+  function onNext() {
     setTimeout(() => {
       navigate(`/model/${id}/making/${mode}/${Number(step) + 1}`);
     }, FEEDBACK_DELAY_TIME);
@@ -71,7 +59,7 @@ function SelectOptionPage({ data, isLoading }: SelectOptionPageProps) {
     <main className={`relative flex-grow ${next ? 'pointer-events-none' : ''}`}>
       <div className="absolute top-0 bottom-0 grid w-full grid-cols-2 lg:grid-cols-12">
         {/* 이미지 영역 */}
-        <div className="lg:col-span-7 flex flex-col justify-center items-center bg-grey-001">
+        <div className="flex flex-col items-center justify-center lg:col-span-7 bg-grey-001">
           {isLoading ? (
             <Spinner />
           ) : Number(step) === EXTERIOR_COLOR_STEP ? (
@@ -122,9 +110,7 @@ function SelectOptionPage({ data, isLoading }: SelectOptionPageProps) {
                 ))
             )}
           </SelectOptionListContainer>
-          <SelectOptionFooter
-            {...{ mode, id, step, onNext: () => onNext(data[selectedItem]) }}
-          />
+          <SelectOptionFooter {...{ mode, id, step, onNext: () => onNext() }} />
         </div>
       </div>
     </main>

--- a/client/src/pages/making/select/SelectOptionPage.tsx
+++ b/client/src/pages/making/select/SelectOptionPage.tsx
@@ -31,6 +31,10 @@ function SelectOptionPage({ data, isLoading }: SelectOptionPageProps) {
   const [selectedItem, setSelectedItem] = useState(-1);
   const [isImageLoading, setIsImageLoading] = useState(true);
   function onNext() {
+    if (mode === 'guide') {
+      return navigate(`/model/${id}/making/${mode}/${Number(step) + 1}`);
+    }
+
     setTimeout(() => {
       navigate(`/model/${id}/making/${mode}/${Number(step) + 1}`);
     }, FEEDBACK_DELAY_TIME);

--- a/client/src/pages/making/select/SelectOptionPage.tsx
+++ b/client/src/pages/making/select/SelectOptionPage.tsx
@@ -42,7 +42,7 @@ function SelectOptionPage({ data, isLoading }: SelectOptionPageProps) {
     Object.values(userSelectedOptionData).forEach(
       ({ options }: { options: OptionGroupType }) => {
         Object.values(options).forEach(({ id, categoryId }) => {
-          if (categoryId === data[0].id) {
+          if (categoryId === data[0].categoryId) {
             data.forEach((item, index) => {
               if (id === item.id) itemIndex = index;
             });
@@ -72,7 +72,7 @@ function SelectOptionPage({ data, isLoading }: SelectOptionPageProps) {
       type: optionTypeName[data[selectedItem].categoryId],
     };
     saveOptionData({ newOption });
-  }, [selectedItem, data]);
+  }, [selectedItem]);
 
   return (
     <>

--- a/client/src/pages/making/select/SelectOptionPage.tsx
+++ b/client/src/pages/making/select/SelectOptionPage.tsx
@@ -15,6 +15,7 @@ import { SelectOptionPageProps } from '@/pages/making/select/type.ts';
 import { optionTypeName } from '@/constant.ts';
 import Spinner from '@/components/Spinner';
 import Skeleton from '@/components/OptionCard/Skeleton.tsx';
+import { OptionGroupType } from '../type';
 
 const EXTERIOR_COLOR_STEP = 5;
 const FEEDBACK_DELAY_TIME = 2000;
@@ -23,12 +24,12 @@ function SelectOptionPage({ data, isLoading }: SelectOptionPageProps) {
   const { step, mode, id } = useParams() as PathParamsType;
   const navigate = useNavigate();
   const [next, setNext] = useState(false);
-  const { saveOptionData } = useContext(UserSelectedOptionDataContext);
-
+  const { userSelectedOptionData, saveOptionData } = useContext(
+    UserSelectedOptionDataContext
+  );
   // 선택 아이템 인덳스
-  const [selectedItem, setSelectedItem] = useState(0);
+  const [selectedItem, setSelectedItem] = useState(-1);
   const [isImageLoading, setIsImageLoading] = useState(true);
-
   function onNext() {
     setTimeout(() => {
       navigate(`/model/${id}/making/${mode}/${Number(step) + 1}`);
@@ -36,14 +37,32 @@ function SelectOptionPage({ data, isLoading }: SelectOptionPageProps) {
     setNext(true);
   }
 
-  useEffect(() => {
-    setNext(false);
-    setSelectedItem(0);
-  }, [data]);
+  function getSelectedItemIndex() {
+    let itemIndex = 0;
+    Object.values(userSelectedOptionData).forEach(
+      ({ options }: { options: OptionGroupType }) => {
+        Object.values(options).forEach(({ id, categoryId }) => {
+          if (categoryId === data[0].id) {
+            data.forEach((item, index) => {
+              if (id === item.id) itemIndex = index;
+            });
+          }
+        });
+      }
+    );
+    return itemIndex;
+  }
 
   useEffect(() => {
     if (!Array.isArray(data)) return;
 
+    const itemIndex = getSelectedItemIndex();
+    setNext(false);
+    setSelectedItem(itemIndex);
+  }, [data]);
+
+  useEffect(() => {
+    if (!Array.isArray(data) || selectedItem === -1) return;
     const newOption = {
       id: data[selectedItem].id,
       name: data[selectedItem].name,
@@ -53,67 +72,75 @@ function SelectOptionPage({ data, isLoading }: SelectOptionPageProps) {
       type: optionTypeName[data[selectedItem].categoryId],
     };
     saveOptionData({ newOption });
-  }, [selectedItem]);
+  }, [selectedItem, data]);
 
   return (
-    <main className={`relative flex-grow ${next ? 'pointer-events-none' : ''}`}>
-      <div className="absolute top-0 bottom-0 grid w-full grid-cols-2 lg:grid-cols-12">
-        {/* 이미지 영역 */}
-        <div className="flex flex-col items-center justify-center lg:col-span-7 bg-grey-001">
-          {isLoading ? (
-            <Spinner />
-          ) : Number(step) === EXTERIOR_COLOR_STEP ? (
-            <RotateCarImage
-              images={getRotateImages({
-                url: data?.[selectedItem]?.images[0].imgUrl ?? '',
-                count: 60,
-              })}
-              className="basis-1/2"
-            />
-          ) : (
-            <>
-              {isImageLoading && <Spinner />}
-              <img
-                src={data?.[selectedItem]?.images[0].imgUrl ?? ''}
-                className={`w-full h-full object-cover ${
-                  isImageLoading && 'hidden'
-                } `}
-                onLoad={() => setIsImageLoading(false)}
-                alt="palisade"
-              />
-            </>
-          )}
-        </div>
-        {/* 옵션 선택 영역 */}
-        <div className="flex flex-col max-w-lg lg:col-span-5">
-          <SelectOptionMessage step={Number(step)} />
-          <SelectOptionListContainer>
-            {isLoading ? (
-              <>
-                <Skeleton />
-                <Skeleton />
-              </>
-            ) : (
-              Array.isArray(data) &&
-              data
-                ?.sort((a, b) => b.rate - a.rate)
-                .map((item: AllOptionType, index) => (
-                  <OptionCard
-                    key={`OptionCard-${item.name}`}
-                    isActive={selectedItem === index}
-                    onClick={() => {
-                      setSelectedItem(index);
-                    }}
-                    item={item}
-                    next={next}
+    <>
+      {selectedItem !== -1 && (
+        <main
+          className={`relative flex-grow ${next ? 'pointer-events-none' : ''}`}
+        >
+          <div className="absolute top-0 bottom-0 grid w-full grid-cols-2 lg:grid-cols-12">
+            {/* 이미지 영역 */}
+            <div className="flex flex-col items-center justify-center lg:col-span-7 bg-grey-001">
+              {isLoading ? (
+                <Spinner />
+              ) : Number(step) === EXTERIOR_COLOR_STEP ? (
+                <RotateCarImage
+                  images={getRotateImages({
+                    url: data?.[selectedItem]?.images[0].imgUrl ?? '',
+                    count: 60,
+                  })}
+                  className="basis-1/2"
+                />
+              ) : (
+                <>
+                  {isImageLoading && <Spinner />}
+                  <img
+                    src={data?.[selectedItem]?.images[0].imgUrl ?? ''}
+                    className={`w-full h-full object-cover ${
+                      isImageLoading && 'hidden'
+                    } `}
+                    onLoad={() => setIsImageLoading(false)}
+                    alt="palisade"
                   />
-                ))
-            )}
-          </SelectOptionListContainer>
-          <SelectOptionFooter {...{ mode, id, step, onNext: () => onNext() }} />
-        </div>
-      </div>
-    </main>
+                </>
+              )}
+            </div>
+            {/* 옵션 선택 영역 */}
+            <div className="flex flex-col max-w-lg lg:col-span-5">
+              <SelectOptionMessage step={Number(step)} />
+              <SelectOptionListContainer>
+                {isLoading ? (
+                  <>
+                    <Skeleton />
+                    <Skeleton />
+                  </>
+                ) : (
+                  Array.isArray(data) &&
+                  data
+                    ?.sort((a, b) => b.rate - a.rate)
+                    .map((item: AllOptionType, index) => (
+                      <OptionCard
+                        key={`OptionCard-${item.name}`}
+                        isActive={selectedItem === index}
+                        onClick={() => {
+                          setSelectedItem(index);
+                        }}
+                        item={item}
+                        next={next}
+                      />
+                    ))
+                )}
+              </SelectOptionListContainer>
+              <SelectOptionFooter
+                {...{ mode, id, step, onNext: () => onNext() }}
+              />
+            </div>
+          </div>
+        </main>
+      )}
+    </>
   );
 }
 

--- a/client/src/utils/getNewOptionData.ts
+++ b/client/src/utils/getNewOptionData.ts
@@ -8,42 +8,33 @@ const CATEGORY = [
   '외장 색상',
   '내장 색상',
   '휠',
-  '옵션',
 ];
 function getNewUserOptionData({
   newData,
   newOption,
-  newOptions,
 }: {
   newData: UserSelectedOptionDataType;
-  newOption?: OptionType;
-  newOptions?: OptionType[];
+  newOption: OptionType;
 }) {
-  if (newOption) {
-    switch (CATEGORY[newOption.categoryId!]) {
-      //TODO: newOption.categoryId -> newOption.categoryName으로 변경
-      //반복되는 newData.mainOptions 와 같은 것 분해할당으로 재활용
-      case '파워 트레인':
-        newData.mainOptions.options.powerTrain = newOption;
-        break;
-      case '구동방식':
-        newData.mainOptions.options.drivingSystem = newOption;
-        break;
-      case '바디 타입':
-        newData.mainOptions.options.bodyType = newOption;
-        break;
-      case '외장 색상':
-        newData.colors.options.exteriorColor = newOption;
-        break;
-      case '내장 색상':
-        newData.colors.options.interiorColor = newOption;
-        break;
-      case '휠':
-        newData.mainOptions.options.wheel = newOption;
-        break;
-    }
-  } else if (newOptions) {
-    newData.selectedOptions.options = newOptions;
+  switch (CATEGORY[newOption.categoryId!]) {
+    case '파워 트레인':
+      newData.mainOptions.options.powerTrain = newOption;
+      break;
+    case '구동방식':
+      newData.mainOptions.options.drivingSystem = newOption;
+      break;
+    case '바디 타입':
+      newData.mainOptions.options.bodyType = newOption;
+      break;
+    case '외장 색상':
+      newData.colors.options.exteriorColor = newOption;
+      break;
+    case '내장 색상':
+      newData.colors.options.interiorColor = newOption;
+      break;
+    case '휠':
+      newData.mainOptions.options.wheel = newOption;
+      break;
   }
   return newData;
 }

--- a/client/src/utils/getNewOptionData.ts
+++ b/client/src/utils/getNewOptionData.ts
@@ -1,38 +1,49 @@
 import { OptionType, UserSelectedOptionDataType } from '@/pages/making/type';
 
+const CATEGORY = [
+  '',
+  '파워 트레인',
+  '구동방식',
+  '바디 타입',
+  '외장 색상',
+  '내장 색상',
+  '휠',
+  '옵션',
+];
 function getNewUserOptionData({
   newData,
   newOption,
+  newOptions,
 }: {
   newData: UserSelectedOptionDataType;
-  newOption: OptionType;
+  newOption?: OptionType;
+  newOptions?: OptionType[];
 }) {
-  switch (newOption.categoryId) {
-    //TODO: newOption.categoryId -> newOption.categoryName으로 변경
-    //반복되는 newData.mainOptions 와 같은 것 분해할당으로 재활용
-    case 1:
-      newData.mainOptions.options.powerTrain = newOption;
-      break;
-    case 2:
-      newData.mainOptions.options.drivingSystem = newOption;
-      break;
-    case 3:
-      newData.mainOptions.options.bodyType = newOption;
-      break;
-    case 6:
-      newData.mainOptions.options.wheel = newOption;
-      break;
-    case 5:
-      newData.colors.options.interiorColor = newOption;
-      break;
-    case 4:
-      newData.colors.options.exteriorColor = newOption;
-      break;
-    case 7:
-      newData.selectedOptions.options.push(newOption);
-      break;
-    default:
-      break;
+  if (newOption) {
+    switch (CATEGORY[newOption.categoryId!]) {
+      //TODO: newOption.categoryId -> newOption.categoryName으로 변경
+      //반복되는 newData.mainOptions 와 같은 것 분해할당으로 재활용
+      case '파워 트레인':
+        newData.mainOptions.options.powerTrain = newOption;
+        break;
+      case '구동방식':
+        newData.mainOptions.options.drivingSystem = newOption;
+        break;
+      case '바디 타입':
+        newData.mainOptions.options.bodyType = newOption;
+        break;
+      case '외장 색상':
+        newData.colors.options.exteriorColor = newOption;
+        break;
+      case '내장 색상':
+        newData.colors.options.interiorColor = newOption;
+        break;
+      case '휠':
+        newData.mainOptions.options.wheel = newOption;
+        break;
+    }
+  } else if (newOptions) {
+    newData.selectedOptions.options = newOptions;
   }
   return newData;
 }

--- a/client/src/utils/getNewOptionsData.ts
+++ b/client/src/utils/getNewOptionsData.ts
@@ -7,7 +7,6 @@ function getNewUserOptionsData({
   newData: UserSelectedOptionDataType;
   newOptions: OptionType[] | undefined;
 }) {
-  console.log(newData);
   if (!newOptions) return newData;
 
   newData.selectedOptions.options = [...newOptions];

--- a/client/src/utils/getNewOptionsData.ts
+++ b/client/src/utils/getNewOptionsData.ts
@@ -1,0 +1,17 @@
+import { OptionType, UserSelectedOptionDataType } from '@/pages/making/type';
+
+function getNewUserOptionsData({
+  newData,
+  newOptions,
+}: {
+  newData: UserSelectedOptionDataType;
+  newOptions: OptionType[] | undefined;
+}) {
+  console.log(newData);
+  if (!newOptions) return newData;
+
+  newData.selectedOptions.options = [...newOptions];
+  return newData;
+}
+
+export default getNewUserOptionsData;


### PR DESCRIPTION
## 📕 요약

선택 옵션 데이터 저장 및 기타 버그 수정
closed #268 

## 📗 작업 내용

- [x] 외장, 내장 색상 데이터 연결
- [x] 선택 옵션 데이터 저장
- [x] 새로 고침 시 데이터가 저장 안되는 버그 수정
- [x] 가이드 모드 키워드 session 저장
- [x] 가이드 모드 키워드 선택 완료 후 견적내기 및 옵션별 선택 기능 이동 구현

## 📘 PR 특이 사항

전체적으로 코드가 파편화 되어 있어서 유기적으로 합쳤습니다.
**session Storage, conext API, 서버로 부터 data fetching 3가지 데이터를 동기적으로 사용하려고 하다 보니 버그가 자주 발생했는데요.**
많은 테스팅을 거치지는 못했는데 발견한 버그 들은 모두 수정했습니다(새로 고침시 데이터 저장 안되는 버그, 선택옵션페이지에서 새로고침 시 선택옵션 제외한 데이터 리셋 버그 등등)

가이드 모드에서 유저의 키워드 기능의 경우 contextAPI 범위가 옵션페이지를 감쌀 수 없어서 session으로 관리하였습니다.

또한 일상님께서 Making Page 컴포넌트에서 params를 선택하는 부분이 분기문이 많아 까다로웠는데 getParams 함수로 따로 구현하여 가독성을 높였습니다.

제가 느끼기에 가장 큰 문제는 하나의 컴포넌트에 너무 많은 일을 하고있어 상태가 너무 많아 렌더링이 자주 발생하는 점입니다.
(특히, 옵션카드 페이지)

최종 발표 전까지 리팩토링을 할 시간이 많지 않아 다소 비효율적이더라도 이대로 가야할 것 같아요🥲

