### PR TITLE
[FE] 숫자 카운팅 애니메이션

### DIFF
--- a/client/src/hooks/useAnimatedPrice.ts
+++ b/client/src/hooks/useAnimatedPrice.ts
@@ -2,7 +2,7 @@ import { useContext, useEffect, useRef, useState } from 'react';
 import { UserSelectedOptionDataContext } from '@/pages/making';
 import getOptionGroupsTotalPrice from '@/utils/getTotalPrice.ts';
 
-function easeOutExpo(t: number): number {
+function easeOutExpo(t: number) {
   return t === 1 ? 1 : 1 - Math.pow(2, -10 * t);
 }
 

--- a/client/src/hooks/useAnimatedPrice.ts
+++ b/client/src/hooks/useAnimatedPrice.ts
@@ -2,6 +2,10 @@ import { useContext, useEffect, useRef, useState } from 'react';
 import { UserSelectedOptionDataContext } from '@/pages/making';
 import getOptionGroupsTotalPrice from '@/utils/getTotalPrice.ts';
 
+function easeOutExpo(t: number): number {
+  return t === 1 ? 1 : 1 - Math.pow(2, -10 * t);
+}
+
 const DURATION = 1000;
 const FRAME_RATE = 1000 / 60;
 
@@ -32,7 +36,7 @@ function useAnimatedPrice() {
     let currentNumber = 0;
     prevCount.current = count;
     const counter = setInterval(() => {
-      const progress = ++currentNumber / totalFrame;
+      const progress = easeOutExpo(++currentNumber / totalFrame);
       setCount(
         totalPrice > prevCount.current
           ? Math.round(

--- a/client/src/hooks/useAnimatedPrice.ts
+++ b/client/src/hooks/useAnimatedPrice.ts
@@ -1,0 +1,57 @@
+import { useContext, useEffect, useRef, useState } from 'react';
+import { UserSelectedOptionDataContext } from '@/pages/making';
+import getOptionGroupsTotalPrice from '@/utils/getTotalPrice.ts';
+
+const DURATION = 1000;
+const FRAME_RATE = 1000 / 60;
+
+function useAnimatedPrice() {
+  const { userSelectedOptionData } = useContext(UserSelectedOptionDataContext);
+  const [totalPrice, setTotalPrice] = useState(
+    Object.values(userSelectedOptionData).reduce(
+      (sum, { options }) => getOptionGroupsTotalPrice(options) + sum,
+      0
+    )
+  );
+  const [count, setCount] = useState(totalPrice);
+
+  const totalFrame = Math.round(DURATION / FRAME_RATE);
+
+  const prevCount = useRef(0);
+
+  useEffect(() => {
+    setTotalPrice(
+      Object.values(userSelectedOptionData).reduce(
+        (sum, { options }) => getOptionGroupsTotalPrice(options) + sum,
+        0
+      )
+    );
+  }, [userSelectedOptionData]);
+
+  useEffect(() => {
+    let currentNumber = 0;
+    prevCount.current = count;
+    const counter = setInterval(() => {
+      const progress = ++currentNumber / totalFrame;
+      setCount(
+        totalPrice > prevCount.current
+          ? Math.round(
+              prevCount.current + (totalPrice - prevCount.current) * progress
+            )
+          : Math.round(
+              prevCount.current - (prevCount.current - totalPrice) * progress
+            )
+      );
+      // prevCount.current = count;
+      if (progress === 1) {
+        clearInterval(counter);
+      }
+    }, FRAME_RATE);
+
+    return () => clearInterval(counter);
+  }, [totalPrice, totalFrame]);
+
+  return count;
+}
+
+export default useAnimatedPrice;

--- a/client/src/hooks/useAnimatedPrice.ts
+++ b/client/src/hooks/useAnimatedPrice.ts
@@ -11,12 +11,13 @@ const FRAME_RATE = 1000 / 60;
 
 function useAnimatedPrice() {
   const { userSelectedOptionData } = useContext(UserSelectedOptionDataContext);
-  const [totalPrice, setTotalPrice] = useState(
-    Object.values(userSelectedOptionData).reduce(
-      (sum, { options }) => getOptionGroupsTotalPrice(options) + sum,
-      0
-    )
+
+  const price = Object.values(userSelectedOptionData).reduce(
+    (sum, { options }) => getOptionGroupsTotalPrice(options) + sum,
+    0
   );
+
+  const [totalPrice, setTotalPrice] = useState(price);
   const [count, setCount] = useState(totalPrice);
 
   const totalFrame = Math.round(DURATION / FRAME_RATE);
@@ -24,12 +25,7 @@ function useAnimatedPrice() {
   const prevCount = useRef(0);
 
   useEffect(() => {
-    setTotalPrice(
-      Object.values(userSelectedOptionData).reduce(
-        (sum, { options }) => getOptionGroupsTotalPrice(options) + sum,
-        0
-      )
-    );
+    setTotalPrice(price);
   }, [userSelectedOptionData]);
 
   useEffect(() => {

--- a/client/src/pages/making/select/SelectOptionFooter.tsx
+++ b/client/src/pages/making/select/SelectOptionFooter.tsx
@@ -1,13 +1,11 @@
-import { PathParamsType } from '@/types/router';
-import { useContext, useState } from 'react';
-
-import { DownArrow } from '@/assets/icons';
+import { useState } from 'react';
 import { Link } from 'react-router-dom';
 import Button from '@/components/Button';
 import SummaryModal from '@/components/SummaryModal';
-import { UserSelectedOptionDataContext } from '..';
-import getOptionGroupsTotalPrice from '@/utils/getTotalPrice';
+import useAnimatedPrice from '@/hooks/useAnimatedPrice.ts';
 import { formatPrice } from '@/utils';
+import { PathParamsType } from '@/types/router';
+import { DownArrow } from '@/assets/icons';
 
 interface SelectOptionFooterProps
   extends Pick<PathParamsType, 'mode' | 'id' | 'step'> {
@@ -24,11 +22,8 @@ function SelectOptionFooter({
 
   const [isSummaryModalOpen, setIsSummaryModalOpen] = useState(false);
 
-  const { userSelectedOptionData } = useContext(UserSelectedOptionDataContext);
-  const totalPrice = Object.values(userSelectedOptionData).reduce(
-    (sum, { options }) => getOptionGroupsTotalPrice(options) + sum,
-    0
-  );
+  const price = useAnimatedPrice();
+
   return (
     <>
       <SummaryModal
@@ -50,9 +45,7 @@ function SelectOptionFooter({
               />
             </span>
           </button>
-          <span className="title1 text-grey-black">
-            {formatPrice(totalPrice)}
-          </span>
+          <span className="title1 text-grey-black">{formatPrice(price)}</span>
         </div>
         <div className="flex items-center gap-21px">
           {currentStep > 1 && (


### PR DESCRIPTION
## 📕 요약

closed #287 

## 📗 작업 내용

커스텀훅을 활용하여 내 차 만들기 플로우의 총 견적 금액 변경시 숫자가 변하는 애니메이션을 추가하였습니다.
처음에는 숫자를 입력받아 이전값과 비교하여 카운팅 애니메이션을 구현하여 제작하였지만, 
선택 옵션 페이지에서 Footer가 새로 렌더링 되면서 0부터 숫자가 증가하기 때문에 가격 상태 유지를 위해서 Context를 가져와 사용하는 방식으로 변경하였습니다.
